### PR TITLE
Introduce a MAC Formatter

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,6 @@
 require 'sequel'
 require 'sinatra/base'
+require './lib/mac_formatter.rb'
 
 class App < Sinatra::Base
   get '/healthcheck' do

--- a/lib/mac_formatter.rb
+++ b/lib/mac_formatter.rb
@@ -1,0 +1,19 @@
+class MacFormatter
+  def execute(mac:)
+    ietf_format(only_hex(uppercase(mac.to_s)))
+  end
+
+private
+
+  def uppercase(mac)
+    mac.upcase
+  end
+
+  def only_hex(mac)
+    mac.gsub(/[^0-F]/, '')
+  end
+
+  def ietf_format(mac)
+    "#{mac[0, 2]}-#{mac[2, 2]}-#{mac[4, 2]}-#{mac[6, 2]}-#{mac[8, 2]}-#{mac[10, 2]}"
+  end
+end

--- a/spec/lib/mac_formatter_spec.rb
+++ b/spec/lib/mac_formatter_spec.rb
@@ -1,0 +1,59 @@
+describe MacFormatter do
+  it 'preserves a correctly formatted MAC' do
+    mac = '50-A6-7F-84-9C-D1'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('50-A6-7F-84-9C-D1')
+  end
+
+  it 'ensures that a MAC is all capital letters' do
+    mac = '50-a6-7f-84-9c-d1'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('50-A6-7F-84-9C-D1')
+  end
+
+  it 'ensures all characters are separated by dashes' do
+    mac = '50A67F849CD1'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('50-A6-7F-84-9C-D1')
+  end
+
+  it 'ensures the rest of the characters are separated by dashes' do
+    mac = '50-A67F849CD1'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('50-A6-7F-84-9C-D1')
+  end
+
+  it 'trims off excess characters' do
+    mac = '50A67F849CD1FF'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('50-A6-7F-84-9C-D1')
+  end
+
+  it 'not enough characters' do
+    mac = 'fff333'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('FF-F3-33---')
+  end
+
+  it 'no valid characters' do
+    mac = 'gggiiijjj'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('-----')
+  end
+
+  it 'formats a mac with a nil value' do
+    mac = nil
+    result = subject.execute(mac: mac)
+    expect(result).to eq('-----')
+  end
+
+  it 'some valid characters' do
+    mac = 'fffiiijjj'
+    result = subject.execute(mac: mac)
+    expect(result).to eq('FF-F----')
+  end
+
+  it 'Throws an error when no MAC argument is supplied' do
+    expect { subject.execute }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Preserve existing MAC formatting functionality from the existing PHP
backend.
We want to ensure that the MAC is in a good format before persisting it
in the session table.

There are some edge cases where we still end up with an invalid MAC.
I have documented this with RSpec examples.
Leaving this as is for now, can revisit later, but ultimately we expect
that the supplied MAC address is in a good format by the end user.

Functionality from here: https://github.com/alphagov/govwifi/blob/master/src/AAA.php#L329