### PR TITLE
Make parameters in post-auth route optional

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,7 @@ class App < Sinatra::Base
     'Healthy'
   end
 
-  get '/logging/post-auth/user/:username/mac/:mac/ap/:called_station_id/site/:site_ip_address/result/:authentication_result' do
+  get '/logging/post-auth/user/?:username?/mac/?:mac?/ap/?:called_station_id?/site/?:site_ip_address?/result/:authentication_result' do
     if params.fetch(:authentication_result) == 'Access-Accept'
       if params.fetch(:username) != 'HEALTH'
         mac = MacFormatter.new.execute(mac: params.fetch(:mac))
@@ -24,9 +24,12 @@ class App < Sinatra::Base
           siteIP: params.fetch(:site_ip_address),
           building_identifier: params.fetch(:called_station_id),
         )
+
         user = User.find(username: params.fetch(:username))
-        user.last_login = Time.now.strftime('%y-%m-%d %H:%M:%S')
-        user.save
+        if user
+          user.last_login = Time.now.strftime('%y-%m-%d %H:%M:%S')
+          user.save
+        end
       end
 
       status 204

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -102,6 +102,21 @@ describe App do
           expect(last_response.status).to eq(404)
         end
       end
+
+      context 'Given parameters are missing from the GET request' do
+        let(:authentication_result) { 'Access-Accept' }
+        let(:username) { '' }
+        let(:called_station_id) { '' }
+        let(:site_ip_address) { '' }
+
+        it 'returns a 204 status code' do
+          expect(last_response.status).to eq(204)
+        end
+
+        it 'creates a session record' do
+          expect(Session.all.count).to eq(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It is not garuanteed that we will receive all the parameters from the
radius servers.
Based on the functionality of the current backend, we will persist empty values.

This even applies to the username which doesn't make much sense because
it cannot be used to identify the indivdual that was authorised.

This functionality can be changed once this current implementation has
been proven to work in production.