### PR TITLE
Ensure either the access point or the building identifier is set

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -15,6 +15,8 @@ module Logging
 
   private
 
+    VALID_MAC_LENGTH = 17
+
     def handle_access_accept(params)
       username = params.fetch(:username)
       return if username == 'HEALTH'
@@ -27,9 +29,9 @@ module Logging
       Session.create(
         username: params.fetch(:username),
         mac: formatted_mac(params.fetch(:mac)),
-        ap: params.fetch(:called_station_id),
+        ap: ap(params.fetch(:called_station_id)),
         siteIP: params.fetch(:site_ip_address),
-        building_identifier: params.fetch(:called_station_id),
+        building_identifier: building_identifier(params.fetch(:called_station_id))
       )
     end
 
@@ -43,6 +45,19 @@ module Logging
 
     def formatted_mac(unformatted_mac)
       MacFormatter.new.execute(mac: unformatted_mac)
+    end
+
+    def valid_mac?(mac)
+      mac.to_s.length == VALID_MAC_LENGTH
+    end
+
+    def building_identifier(called_station_id)
+      called_station_id if !valid_mac?(called_station_id)
+    end
+
+    def ap(mac)
+      return mac if valid_mac?(formatted_mac(mac))
+      ''
     end
   end
 end

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -55,8 +55,9 @@ module Logging
       called_station_id if !valid_mac?(called_station_id)
     end
 
-    def ap(mac)
-      return mac if valid_mac?(formatted_mac(mac))
+    def ap(unformatted_mac)
+      mac = formatted_mac(unformatted_mac)
+      return mac if valid_mac?(mac)
       ''
     end
   end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -43,6 +43,14 @@ describe App do
           it 'does not save it as the building identifier' do
             expect(session.building_identifier).to be_nil
           end
+
+          context 'Given the Called Station ID needs to be formatted' do
+            let(:called_station_id) { 'aa-bb-cc-25-2a-80' }
+
+            it 'formats the Called Station ID' do
+              expect(session.ap).to eq('AA-BB-CC-25-2A-80')
+            end
+          end
         end
 
         context 'Given the "Called Station ID" is a building identifier' do

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -7,10 +7,11 @@ describe App do
   describe 'POST post-auth' do
     let(:username) { 'vykzdx' }
     let(:mac) { 'DA-59-19-8B-39-2D' }
-    let(:called_station_id) { '01-39-38-25-2a-80' }
+    let(:called_station_id) { '01-39-38-25-2A-80' }
     let(:site_ip_address) { '93.11.238.187' }
     let(:post_auth_request) { get "/logging/post-auth/user/#{username}/mac/#{mac}/ap/#{called_station_id}/site/#{site_ip_address}/result/#{authentication_result}" }
     let(:user) { User.find(username: username) }
+    let(:session) { Session.first }
 
     before do
       User.create(username: username)
@@ -26,13 +27,46 @@ describe App do
         end
 
         it 'records the session details' do
-          session = Session.first
-
           expect(session.username).to eq(username)
           expect(session.mac).to eq(mac)
           expect(session.ap).to eq(called_station_id)
           expect(session.siteIP).to eq(site_ip_address)
-          expect(session.building_identifier).to eq(called_station_id)
+        end
+
+        context 'Given the "Called Station ID" is an MAC address' do
+          let(:called_station_id) { '01-39-38-25-2A-80' }
+
+          it 'saves it as the access point' do
+            expect(session.ap).to eq(called_station_id)
+          end
+
+          it 'does not save it as the building identifier' do
+            expect(session.building_identifier).to be_nil
+          end
+        end
+
+        context 'Given the "Called Station ID" is a building identifier' do
+          let(:called_station_id) { 'Building-Identifier' }
+
+          it 'saves it as a building identifier' do
+            expect(session.building_identifier).to eq(called_station_id)
+          end
+
+          it 'does not save it as an access point' do
+            expect(session.ap).to eq('')
+          end
+        end
+
+        context 'Given a blank "Called Station ID"' do
+          let(:called_station_id) { '' }
+
+          it 'does not save the ap' do
+            expect(session.ap).to eq('')
+          end
+
+          it 'does not save the building_identifier' do
+            expect(session.building_identifier).to be_nil
+          end
         end
 
         context 'HEALTH user' do


### PR DESCRIPTION
The "Called Station ID" param can contain either an access point value
or a building identifier.  Once formatted, we can see if it is 17 chars
long and know that it is an acces point identifier.  If it is not blank
and not a valid MAC, we can assume that it is a building identifier.

Persist either the ap or the building identifier.