### PR TITLE
Fix bug Called Station ID saved as an Access Point

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -52,7 +52,7 @@ module Logging
     end
 
     def building_identifier(called_station_id)
-      called_station_id if !valid_mac?(called_station_id)
+      called_station_id if !valid_mac?(formatted_mac(called_station_id))
     end
 
     def ap(unformatted_mac)

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -51,6 +51,15 @@ describe App do
               expect(session.ap).to eq('AA-BB-CC-25-2A-80')
             end
           end
+
+          context 'Given a Called Station ID has extra trailing characters' do
+            let(:called_station_id) { 'C4-13-E2-22-DC-55%3ASTAGING-GovWifi' }
+
+            it 'Formats it and considers it a valid access point' do
+              expect(session.ap).to eq('C4-13-E2-22-DC-55')
+              expect(session.building_identifier).to be_nil
+            end
+          end
         end
 
         context 'Given the "Called Station ID" is a building identifier' do


### PR DESCRIPTION
When we receive a Called Station ID we check whether it is a valid MAC.
If it is, save it as an Access Point, otherwise try save it as a
building identifier.

When checking whether it's a valid Access Point, we need to check its
formatted version, which this code wasn't doing previously.