### PR TITLE
Record start time for a session

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -27,7 +27,7 @@ module Logging
 
     def create_session(params)
       Session.create(
-        start: Time.now.strftime('%Y-%m-%d %H:%M:%S'),
+        start: Time.now,
         username: params.fetch(:username),
         mac: formatted_mac(params.fetch(:mac)),
         ap: ap(params.fetch(:called_station_id)),
@@ -40,7 +40,7 @@ module Logging
       user = User.find(username: username)
       return unless user
 
-      user.last_login = Time.now.strftime('%Y-%m-%d %H:%M:%S')
+      user.last_login = Time.now
       user.save
     end
 

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -27,6 +27,7 @@ module Logging
 
     def create_session(params)
       Session.create(
+        start: Time.now.strftime('%Y-%m-%d %H:%M:%S'),
         username: params.fetch(:username),
         mac: formatted_mac(params.fetch(:mac)),
         ap: ap(params.fetch(:called_station_id)),
@@ -39,7 +40,7 @@ module Logging
       user = User.find(username: username)
       return unless user
 
-      user.last_login = Time.now.strftime('%y-%m-%d %H:%M:%S')
+      user.last_login = Time.now.strftime('%Y-%m-%d %H:%M:%S')
       user.save
     end
 

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -26,6 +26,15 @@ describe App do
           expect(Session.count).to eq(1)
         end
 
+        it 'updates the user last login' do
+          post_auth_request
+          expect(user.last_login).to_not be_nil
+        end
+
+        it 'records the start time of the session' do
+          expect(session.start).to_not be_nil
+        end
+
         it 'records the session details' do
           expect(session.username).to eq(username)
           expect(session.mac).to eq(mac)
@@ -100,13 +109,6 @@ describe App do
 
           it 'does not create a session record' do
             expect(Session.count).to eq(0)
-          end
-        end
-
-        context 'GovWifi user' do
-          it 'updates the last login' do
-            post_auth_request
-            expect(user.last_login).to_not be_nil
           end
         end
       end


### PR DESCRIPTION
This functionality was missing, so add it with this commit.
When we create a session record, we populate the start time with the
current time.

Also fix date format with strftime in for userdetails last_login, it was
using %y which is a date like 18, not 2018. MYSQL overlooked this and
saved it correctly anyway, but fix the code for consistency.