### PR TITLE
Usernames are always saved as uppercase

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -28,7 +28,7 @@ module Logging
     def create_session(params)
       Session.create(
         start: Time.now,
-        username: params.fetch(:username),
+        username: username(params.fetch(:username)),
         mac: formatted_mac(params.fetch(:mac)),
         ap: ap(params.fetch(:called_station_id)),
         siteIP: params.fetch(:site_ip_address),
@@ -54,6 +54,10 @@ module Logging
 
     def building_identifier(called_station_id)
       called_station_id if !valid_mac?(formatted_mac(called_station_id))
+    end
+
+    def username(unformatted_username)
+      unformatted_username.to_s.upcase
     end
 
     def ap(unformatted_mac)

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -5,7 +5,7 @@ describe App do
   end
 
   describe 'POST post-auth' do
-    let(:username) { 'vykzdx' }
+    let(:username) { 'VYKZDX' }
     let(:mac) { 'DA-59-19-8B-39-2D' }
     let(:called_station_id) { '01-39-38-25-2A-80' }
     let(:site_ip_address) { '93.11.238.187' }
@@ -29,6 +29,14 @@ describe App do
         it 'updates the user last login' do
           post_auth_request
           expect(user.last_login).to_not be_nil
+        end
+
+        context 'given a lowercase username' do
+          let(:username) { 'abcdef' }
+
+          it 'ensures that the username is saved in uppercase' do
+            expect(session.username).to eq('ABCDEF')
+          end
         end
 
         it 'records the start time of the session' do


### PR DESCRIPTION
Previously we would save the username exactly as it came in from the url parameters.
Current backend behaviour always ensures that the username is presisted in uppercase, so preserve this functionality.