### PR TITLE
Generate statistics for sessions from the database

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,9 +1,12 @@
 require 'sequel'
 require 'sinatra/base'
+require './lib/loader'
 require './lib/mac_formatter.rb'
 require './lib/session.rb'
 require './lib/user.rb'
 require './lib/logging/post_auth.rb'
+require './lib/performance_platform/gateway/account_usage.rb'
+require './lib/performance_platform/repository/session.rb'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,0 +1,4 @@
+module PerformancePlatform
+  module Gateway; end
+  module Repository; end
+end

--- a/lib/performance_platform/gateway/account_usage.rb
+++ b/lib/performance_platform/gateway/account_usage.rb
@@ -1,0 +1,20 @@
+class PerformancePlatform::Gateway::AccountUsage
+  def fetch_stats
+    result = repository.stats || Hash.new(0)
+
+    {
+      total: result[:total].to_i,
+      transactions: result[:per_site],
+      roaming: result[:per_site] - result[:total],
+      one_time: result[:total] - (result[:per_site] - result[:total]),
+      metric_name: 'account-usage',
+      period: 'day'
+    }
+  end
+
+private
+
+  def repository
+    PerformancePlatform::Repository::Session
+  end
+end

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,0 +1,18 @@
+class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
+  dataset_module do
+    def stats
+      DB.fetch("
+      SELECT
+      count(distinct(username)) as total,
+      count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
+      FROM sessions
+      LEFT JOIN siteip
+      ON (siteip.ip = sessions.siteIP)
+      LEFT JOIN site
+      ON (siteip.site_id = site.id)
+      WHERE site.org_id IS NOT NULL
+      AND date(sessions.start) = '#{Date.today - 1}'
+      GROUP BY date(start)").first
+    end
+  end
+end

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -1,0 +1,89 @@
+describe PerformancePlatform::Gateway::AccountUsage do
+  let(:session_repository) { DB[:sessions] }
+  let(:site_repository) { DB[:site] }
+  let(:site_ip_repository) { DB[:siteip] }
+
+  before do
+    DB[:sessions].truncate
+    DB[:siteip].truncate
+    DB[:site].truncate
+  end
+
+  context 'given no sessions' do
+    it 'returns stats with zero sessions' do
+      expect(subject.fetch_stats).to eq(
+        total: 0,
+        transactions: 0,
+        roaming: 0,
+        one_time: 0,
+        metric_name: 'account-usage',
+        period: 'day',
+      )
+    end
+  end
+
+  context 'given many sessions' do
+    before do
+      session_repository.insert(
+        siteIP: '127.0.0.1',
+        username: 'bob',
+        start: Date.today - 1
+      )
+
+      session_repository.insert(
+        siteIP: '127.0.0.9',
+        username: 'bob',
+        start: Date.today - 1
+      )
+
+      session_repository.insert(
+        siteIP: '127.0.0.1',
+        username: 'bob',
+        start: Date.today - 1
+      )
+
+      session_repository.insert(
+        siteIP: '127.0.0.9',
+        username: 'alice',
+        start: Date.today - 1
+      )
+
+      session_repository.insert(
+        siteIP: '127.0.0.9',
+        username: 'alice',
+        start: Date.today - 2
+      )
+
+      site1_id = site_repository.insert(
+        address: 'hello',
+        org_id: 1
+      )
+
+      site2_id = site_repository.insert(
+        address: 'foo',
+        org_id: 2
+      )
+
+      site_ip_repository.insert(
+        ip: '127.0.0.1',
+        site_id: site1_id
+      )
+
+      site_ip_repository.insert(
+        ip: '127.0.0.9',
+        site_id: site2_id
+      )
+    end
+
+    it 'returns stats for sessions' do
+      expect(subject.fetch_stats).to eq(
+        total: 2,
+        transactions: 3,
+        roaming: 1,
+        one_time: 1,
+        metric_name: 'account-usage',
+        period: 'day',
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is the basic functionality to get the statistics from the database
in raw form.

A later commit will introduce a presenter to transform
these results into something the performance platform will accept.

Nothing uses this yet, a later commit will introduce the rake task to
send these over to the performance platform.