### PR TITLE
Send performance stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ ruby File.read('.ruby-version').chomp
 
 gem 'mysql2'
 gem 'puma'
+gem 'rake', '~> 12.3'
+gem 'require_all'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.3'
 gem 'sinatra'

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :test do
   gem 'govuk-lint'
   gem 'rack-test'
   gem 'rspec'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    require_all (2.0.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -111,6 +112,8 @@ DEPENDENCIES
   mysql2
   puma
   rack-test
+  rake (~> 12.3)
+  require_all
   rspec
   sentry-raven
   sequel (~> 5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,13 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     backports (3.11.3)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -17,6 +21,7 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
+    hashdiff (0.3.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
@@ -28,6 +33,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    public_suffix (3.0.2)
     puma (3.12.0)
     rack (2.0.5)
     rack-protection (2.0.3)
@@ -62,6 +68,7 @@ GEM
     rubocop-rspec (1.19.0)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
+    safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -91,6 +98,10 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -105,6 +116,7 @@ DEPENDENCIES
   sequel (~> 5.3)
   sinatra
   sinatra-contrib
+  webmock
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require './lib/loader'
+
+require './tasks/publish_statistics'

--- a/app.rb
+++ b/app.rb
@@ -1,16 +1,6 @@
 require 'sequel'
 require 'sinatra/base'
 require './lib/loader'
-require './lib/mac_formatter.rb'
-require './lib/session.rb'
-require './lib/user.rb'
-require './lib/logging/post_auth.rb'
-require './lib/performance_platform/gateway/account_usage.rb'
-require './lib/performance_platform/repository/session.rb'
-require './lib/performance_platform/use_case/send_performance_report'
-require './lib/performance_platform/presenter/account_usage'
-require './lib/common/base64'
-require './lib/performance_platform/gateway/performance_report'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do

--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,10 @@ require './lib/user.rb'
 require './lib/logging/post_auth.rb'
 require './lib/performance_platform/gateway/account_usage.rb'
 require './lib/performance_platform/repository/session.rb'
+require './lib/performance_platform/use_case/send_performance_report'
+require './lib/performance_platform/presenter/account_usage'
+require './lib/common/base64'
+require './lib/performance_platform/gateway/performance_report'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-RACK_ENV = ENV['RACK_ENV'] ||= 'development' unless defined?(RACK_ENV)
+RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
 if %w[production staging].include?(RACK_ENV)
   require 'raven'
@@ -9,16 +9,6 @@ if %w[production staging].include?(RACK_ENV)
 
   use Raven::Rack
 end
-
-require 'sequel'
-
-DB = Sequel.connect(
-  adapter: 'mysql2',
-  host: ENV.fetch('DB_HOSTNAME'),
-  database: ENV.fetch('DB_NAME'),
-  user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS')
-)
 
 require './app'
 run App

--- a/lib/common/base64.rb
+++ b/lib/common/base64.rb
@@ -1,0 +1,5 @@
+class Common::Base64
+  def self.encode_array(arr)
+    Base64.strict_encode64(arr.join)
+  end
+end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,3 +1,17 @@
+require 'sequel'
+require 'require_all'
+
+DB = Sequel.connect(
+  adapter: 'mysql2',
+  host: ENV.fetch('DB_HOSTNAME'),
+  database: ENV.fetch('DB_NAME'),
+  user: ENV.fetch('DB_USER'),
+  password: ENV.fetch('DB_PASS')
+)
+
+module Common;
+end
+
 module PerformancePlatform
   module Gateway; end
   module Repository; end
@@ -5,5 +19,5 @@ module PerformancePlatform
   module Presenter; end
 end
 
-module Common;
-end
+
+require_all 'lib'

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,4 +1,9 @@
 module PerformancePlatform
   module Gateway; end
   module Repository; end
+  module UseCase; end
+  module Presenter; end
+end
+
+module Common;
 end

--- a/lib/performance_platform/gateway/performance_report.rb
+++ b/lib/performance_platform/gateway/performance_report.rb
@@ -1,0 +1,41 @@
+class PerformancePlatform::Gateway::HttpError < StandardError; end
+
+class PerformancePlatform::Gateway::PerformanceReport
+  def send_stats(data)
+    uri = build_url(data)
+
+    post(uri, data)
+  end
+
+private
+
+  def post(uri, data)
+    request = Net::HTTP::Post.new(uri)
+    request['Authorization'] = build_bearer_token(data)
+    request['Content-Type'] = 'application/json'
+    request.body = data[:payload].to_json
+
+    Net::HTTP.start(uri.hostname, 443, use_ssl: true) do |http|
+      response = http.request(request)
+
+      raise PerformancePlatform::Gateway::HttpError, "#{response.code} - #{response.body}" \
+        unless response.code == '200'
+
+      JSON.parse(response.body)
+    end
+  end
+
+  def build_url(data)
+    performance_url = ENV.fetch('PERFORMANCE_URL')
+    dataset_name = ENV.fetch('PERFORMANCE_DATASET')
+    metric_name = data[:metric_name]
+
+    URI("#{performance_url}data/#{dataset_name}/#{metric_name}")
+  end
+
+  def build_bearer_token(data)
+    bearer_const_name = data[:metric_name].tr('-', '_').upcase
+
+    "Bearer #{ENV.fetch('PERFORMANCE_BEARER_' + bearer_const_name)}"
+  end
+end

--- a/lib/performance_platform/presenter/account_usage.rb
+++ b/lib/performance_platform/presenter/account_usage.rb
@@ -1,0 +1,47 @@
+class PerformancePlatform::Presenter::AccountUsage
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        as_hash(stats[:total], 'total'),
+        as_hash(stats[:transactions], 'transactions'),
+        as_hash(stats[:roaming], 'roaming'),
+        as_hash(stats[:one_time], 'one-time'),
+      ]
+    }
+  end
+
+private
+
+  def generate_timestamp
+    "#{Date.today - 1}T00:00:00+00:00"
+  end
+
+  def as_hash(count, type)
+    {
+      _id: encode_id(type),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      type: type,
+      count: count
+    }
+  end
+
+  def encode_id(type)
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch('PERFORMANCE_DATASET'),
+        stats[:period],
+        stats[:metric_name],
+        type
+      ]
+    )
+  end
+
+  attr_reader :stats, :timestamp
+end

--- a/lib/performance_platform/use_case/send_performance_report.rb
+++ b/lib/performance_platform/use_case/send_performance_report.rb
@@ -1,0 +1,17 @@
+class PerformancePlatform::UseCase::SendPerformanceReport
+  def initialize(stats_gateway:, performance_gateway:)
+    @stats_gateway = stats_gateway
+    @performance_gateway = performance_gateway
+  end
+
+  def execute(presenter:)
+    stats = stats_gateway.fetch_stats
+    performance_data = presenter.present(stats: stats)
+
+    performance_gateway.send_stats(performance_data)
+  end
+
+private
+
+  attr_reader :stats_gateway, :performance_gateway
+end

--- a/spec/lib/common/base64_spec.rb
+++ b/spec/lib/common/base64_spec.rb
@@ -1,0 +1,9 @@
+describe Common::Base64 do
+  context '#encode_array' do
+    it 'joins array contents and encodes it' do
+      arr = %w(foo bar baz)
+
+      expect(described_class.encode_array(arr)).to eq('Zm9vYmFyYmF6')
+    end
+  end
+end

--- a/spec/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/lib/performance_platform/gateway/performance_report_spec.rb
@@ -1,0 +1,44 @@
+describe PerformancePlatform::Gateway::PerformanceReport do
+  let(:endpoint) { 'https://performance-platform/' }
+  let(:data) { { metric_name: 'volumetrics', payload: [{ foo: :bar }] } }
+
+  before do
+    ENV['PERFORMANCE_BEARER_VOLUMETRICS'] = 'foobarbaz'
+    ENV['PERFORMANCE_URL'] = endpoint
+    ENV['PERFORMANCE_DATASET'] = 'gov-wifi'
+
+    stub_request(:post, "#{endpoint}data/gov-wifi/volumetrics")
+    .with(
+      body: data[:payload].to_json,
+      headers: {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer foobarbaz"
+      }
+    )
+    .to_return(
+      body: response.to_json,
+      status: response_code
+    )
+  end
+
+  context 'with valid data sent' do
+    let(:response) { { status: 'ok' } }
+    let(:response_code) { 200 }
+
+    it 'returns an OK response' do
+      result = subject.send_stats(data)
+
+      expect(result['status']).to eq('ok')
+    end
+  end
+
+  context 'with invalid data' do
+    let(:response) { 'error message' }
+    let(:response_code) { 403 }
+
+    it 'rasises an error' do
+      expect { subject.send_stats(data) }.to \
+        raise_error(PerformancePlatform::Gateway::HttpError, '403 - "error message"')
+    end
+  end
+end

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -1,0 +1,95 @@
+describe PerformancePlatform::UseCase::SendPerformanceReport do
+  let(:performance_gateway) { PerformancePlatform::Gateway::PerformanceReport.new }
+  let(:endpoint) { 'https://performance-platform/' }
+  let(:response) { { status: 'ok' } }
+
+  before do
+    allow(presenter).to receive(:generate_timestamp).and_return('2018-07-16T00:00:00+00:00')
+
+    expect(stats_gateway).to receive(:fetch_stats)
+      .and_return(stats_gateway_response)
+
+    ENV['PERFORMANCE_BEARER_ACCOUNT_USAGE'] = 'googoogoo'
+    ENV['PERFORMANCE_URL'] = endpoint
+    ENV['PERFORMANCE_DATASET'] = dataset
+
+    stub_request(:post, "#{endpoint}data/#{dataset}/#{metric}")
+    .with(
+      body: data[:payload].to_json,
+      headers: {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{bearer_token}"
+      }
+    )
+    .to_return(
+      body: response.to_json,
+      status: 200
+    )
+  end
+
+  subject do
+    described_class.new(
+      stats_gateway: stats_gateway,
+      performance_gateway: performance_gateway
+    )
+  end
+
+  context 'report for account usage' do
+    let(:metric) { 'account-usage' }
+    let(:dataset) { 'gov-wifi' }
+    let(:bearer_token) { 'googoogoo' }
+    let(:presenter) { PerformancePlatform::Presenter::AccountUsage.new }
+    let(:stats_gateway) { PerformancePlatform::Gateway::AccountUsage.new }
+    let(:stats_gateway_response) {
+      {
+        total: 2,
+        transactions: 3,
+        roaming: 1,
+        one_time: 1,
+        metric_name: 'account-usage',
+        period: 'day'
+      }
+    }
+
+    let(:data) {
+      {
+        metric_name: 'account-usage',
+        payload: [
+          {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXRvdGFs',
+            _timestamp: '2018-07-16T00:00:00+00:00',
+            dataType: 'account-usage',
+            period: 'day',
+            type: 'total',
+            count: 2
+          }, {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXRyYW5zYWN0aW9ucw==',
+            _timestamp: '2018-07-16T00:00:00+00:00',
+            dataType: 'account-usage',
+            period: 'day',
+            type: 'transactions',
+            count: 3
+          }, {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXJvYW1pbmc=',
+            _timestamp: '2018-07-16T00:00:00+00:00',
+            dataType: 'account-usage',
+            period: 'day',
+            type: 'roaming',
+            count: 1
+          }, {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZW9uZS10aW1l',
+            _timestamp: '2018-07-16T00:00:00+00:00',
+            dataType: 'account-usage',
+            period: 'day',
+            type: 'one-time',
+            count: 1
+          }
+        ]
+      }
+    }
+
+    it 'fetches stats and sends them to Performance service' do
+      expect(subject.execute(presenter: presenter)['status']).to eq('ok')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rack/test'
 require 'rspec'
 require 'sequel'
+require 'webmock/rspec'
 
 ENV['RACK_ENV'] = 'test'
 

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -1,0 +1,10 @@
+task :publish_daily_statistics do
+  performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
+  account_usage_gateway = PerformancePlatform::Gateway::AccountUsage.new
+  account_usage_presenter = PerformancePlatform::Presenter::AccountUsage.new
+
+  PerformancePlatform::UseCase::SendPerformanceReport.new(
+    stats_gateway: account_usage_gateway,
+    performance_gateway: performance_gateway
+  ).execute(presenter: account_usage_presenter)
+end


### PR DESCRIPTION
Remaining required functionality for sending over AccountUsage statistics.

This introduces the use cases to send the correctly formatted data over
to the performance platform.

Also some minor refactoring.

