### PR TITLE
Increase the read timeout for Sequel gem

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -6,7 +6,8 @@ DB = Sequel.connect(
   host: ENV.fetch('DB_HOSTNAME'),
   database: ENV.fetch('DB_NAME'),
   user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS')
+  password: ENV.fetch('DB_PASS'),
+  read_timeout: 9999
 )
 
 module Common;


### PR DESCRIPTION
We're running into issue where a long running sql query (roughly 10
minutes) is being cancelled by the ruby client.

We suspect that increasing this timeout value will prevent this from
happening but needs to be tested against the production dataset.

Set the timeout to 9999, which should be more than enough time