### PR TITLE
Explicitly require base64

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'sequel'
 require 'require_all'
 
@@ -18,6 +19,5 @@ module PerformancePlatform
   module UseCase; end
   module Presenter; end
 end
-
 
 require_all 'lib'


### PR DESCRIPTION
We are seeing an error in production where Base64 is not required.
Our automated tests aren't picking this up but we suspect it's being
required by a testing library.

Explicitly require base64 so we can use it.