### PR TITLE
Require Net/Http explicitly

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,6 +1,7 @@
 require 'base64'
 require 'sequel'
 require 'require_all'
+require 'net/http'
 
 DB = Sequel.connect(
   adapter: 'mysql2',


### PR DESCRIPTION
Same error as with the Base64 library it seems we have to explicitly
require net/http.

Once again some test library must be including this which means we don't
see the same errors in production as in the test environment.