### PR TITLE
Require JSON library explicitly

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'sequel'
 require 'require_all'
 require 'net/http'
+require 'json'
 
 DB = Sequel.connect(
   adapter: 'mysql2',


### PR DESCRIPTION
Similar to previous issues, we don't have a JSON library available in
the production environment (but we do in the test environment), so add
it.