### PR TITLE
Aggregate account usage statistics by week instead of a day

### DIFF
--- a/lib/performance_platform/gateway/account_usage.rb
+++ b/lib/performance_platform/gateway/account_usage.rb
@@ -8,7 +8,7 @@ class PerformancePlatform::Gateway::AccountUsage
       roaming: result[:per_site] - result[:total],
       one_time: result[:total] - (result[:per_site] - result[:total]),
       metric_name: 'account-usage',
-      period: 'day'
+      period: 'week'
     }
   end
 

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,18 +1,25 @@
 class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
+  # rubocop:disable Metrics/BlockLength
   dataset_module do
     def stats
-      DB.fetch("
-      SELECT
-      count(distinct(username)) as total,
-      count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
-      FROM sessions
-      LEFT JOIN siteip
-      ON (siteip.ip = sessions.siteIP)
-      LEFT JOIN site
-      ON (siteip.site_id = site.id)
-      WHERE site.org_id IS NOT NULL
-      AND date(sessions.start) = '#{Date.today - 1}'
-      GROUP BY date(start)").first
+      result = DB.fetch("SELECT
+        count(distinct(username)) as total,
+        count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
+        FROM sessions
+          LEFT JOIN siteip
+          ON (siteip.ip = sessions.siteIP)
+          LEFT JOIN site
+          ON (siteip.site_id = site.id)
+        WHERE site.org_id IS NOT NULL
+        AND start
+          BETWEEN date_sub('#{Date.today - 1}', INTERVAL 1 WEEK)
+          AND '#{Date.today - 1}'
+        GROUP BY date(start);").all
+
+      {
+        total: result.sum { |a| a[:total] },
+        per_site: result.sum { |a| a[:per_site] },
+      }
     end
 
     def unique_users_stats(period:)
@@ -26,4 +33,5 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
       DB.fetch(sql).first
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -17,7 +17,7 @@ describe PerformancePlatform::Gateway::AccountUsage do
         roaming: 0,
         one_time: 0,
         metric_name: 'account-usage',
-        period: 'day',
+        period: 'week',
       )
     end
   end
@@ -51,6 +51,12 @@ describe PerformancePlatform::Gateway::AccountUsage do
       session_repository.insert(
         siteIP: '127.0.0.9',
         username: 'alice',
+        start: Date.today - 1
+      )
+
+      session_repository.insert(
+        siteIP: '127.0.0.9',
+        username: 'george',
         start: Date.today - 2
       )
 
@@ -77,12 +83,12 @@ describe PerformancePlatform::Gateway::AccountUsage do
 
     it 'returns stats for sessions' do
       expect(subject.fetch_stats).to eq(
-        total: 2,
-        transactions: 3,
+        total: 3,
+        transactions: 4,
         roaming: 1,
-        one_time: 1,
+        one_time: 2,
         metric_name: 'account-usage',
-        period: 'day',
+        period: 'week',
       )
     end
   end

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -48,7 +48,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         roaming: 1,
         one_time: 1,
         metric_name: 'account-usage',
-        period: 'day'
+        period: 'week'
       }
     }
 
@@ -57,31 +57,34 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         metric_name: 'account-usage',
         payload: [
           {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXRvdGFs',
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjY291bnQtdXNhZ2V0b3RhbA==',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'account-usage',
-            period: 'day',
+            period: 'week',
             type: 'total',
             count: 2
-          }, {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXRyYW5zYWN0aW9ucw==',
+          },
+          {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjY291bnQtdXNhZ2V0cmFuc2FjdGlvbnM=',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'account-usage',
-            period: 'day',
+            period: 'week',
             type: 'transactions',
             count: 3
-          }, {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZXJvYW1pbmc=',
+          },
+          {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjY291bnQtdXNhZ2Vyb2FtaW5n',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'account-usage',
-            period: 'day',
+            period: 'week',
             type: 'roaming',
             count: 1
-          }, {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5YWNjb3VudC11c2FnZW9uZS10aW1l',
+          },
+          {
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjY291bnQtdXNhZ2VvbmUtdGltZQ==',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'account-usage',
-            period: 'day',
+            period: 'week',
             type: 'one-time',
             count: 1
           }


### PR DESCRIPTION
In particular roaming statistics are most useful when computed
against a period of a week instead of a day because it's more
likely that people will travel between government buildings
in that period, not in a single day.