### PR TITLE
Fix query for unique user statistics

### DIFF
--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -16,14 +16,16 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
     end
 
     def unique_users_stats(period:)
-      sql = "SELECT count(distinct(username)) as `count`
-        FROM sessions
-        WHERE start
-          BETWEEN date_sub('#{Date.today}', INTERVAL 1 #{period.to_s.upcase})
-          AND '#{Date.today}'
-        AND dayofweek(start) NOT IN (1,7)"
+      sql = "
+      SELECT start AS day, count(distinct(username)) AS users FROM sessions
+      WHERE start BETWEEN date_sub('#{Date.today}', INTERVAL 1 #{period.to_s.upcase})
+      AND '#{Date.today}'
+      AND dayofweek(start) NOT IN (1,7)
+      GROUP BY day"
 
-      DB.fetch(sql).first
+      result = DB.fetch(sql).all.sum { |r| r[:users].to_i }
+
+      { count: result }
     end
   end
 end


### PR DESCRIPTION
Simplifying this query turned out to break it.
Restored the original query but had trouble testing this since the
Sequel gem converts date values into date objects.  Trying to group by
these date objects doesn't work as expected.

Introduce an extra step in ruby to do the grouping.

There will be no performance impact, and the amount of rows returned is
small