### PR TITLE
Revert to non-aggregated version of account usage

### DIFF
--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,25 +1,18 @@
 class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
-  # rubocop:disable Metrics/BlockLength
   dataset_module do
-    def account_usage_stats(period:)
-      result = DB.fetch("SELECT
-        count(distinct(username)) as total,
-        count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
-        FROM sessions
-          LEFT JOIN siteip
-          ON (siteip.ip = sessions.siteIP)
-          LEFT JOIN site
-          ON (siteip.site_id = site.id)
-        WHERE site.org_id IS NOT NULL
-        AND start
-          BETWEEN date_sub('#{Date.today - 1}', INTERVAL 1 #{period})
-          AND '#{Date.today - 1}'
-        GROUP BY date(start);").all
-
-      {
-        total: result.sum { |a| a[:total] },
-        per_site: result.sum { |a| a[:per_site] },
-      }
+    def account_usage_stats(*)
+      DB.fetch("
+       SELECT
+         count(distinct(username)) as total,
+         count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
+         FROM sessions
+         LEFT JOIN siteip
+         ON (siteip.ip = sessions.siteIP)
+         LEFT JOIN site
+         ON (siteip.site_id = site.id)
+           WHERE site.org_id IS NOT NULL
+           AND date(sessions.start) = '#{Date.today - 1}'
+      GROUP BY date(start)").first
     end
 
     def unique_users_stats(period:)
@@ -31,5 +24,4 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
       DB.fetch(sql).first
     end
   end
-  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -85,10 +85,10 @@ describe PerformancePlatform::Gateway::AccountUsage do
 
     it 'returns stats for sessions' do
       expect(subject.fetch_stats).to eq(
-        total: 3,
-        transactions: 4,
+        total: 2,
+        transactions: 3,
         roaming: 1,
-        one_time: 2,
+        one_time: 1,
         metric_name: 'account-usage',
         period: 'week',
       )


### PR DESCRIPTION
Aggregation should be done on the dashboard side instead of
on the SQL side.