### PR TITLE
Silence Logger in test environment

### DIFF
--- a/lib/performance_platform/use_case/send_performance_report.rb
+++ b/lib/performance_platform/use_case/send_performance_report.rb
@@ -1,13 +1,13 @@
 require 'logger'
 
 class PerformancePlatform::UseCase::SendPerformanceReport
-  def initialize(stats_gateway:, performance_gateway:)
+  def initialize(stats_gateway:, performance_gateway:, logger: Logger.new(STDOUT))
     @stats_gateway = stats_gateway
     @performance_gateway = performance_gateway
+    @logger = logger
   end
 
   def execute(presenter:)
-    logger = Logger.new(STDOUT)
     stats = stats_gateway.fetch_stats
     performance_data = presenter.present(stats: stats)
 
@@ -17,5 +17,5 @@ class PerformancePlatform::UseCase::SendPerformanceReport
 
 private
 
-  attr_reader :stats_gateway, :performance_gateway
+  attr_reader :stats_gateway, :performance_gateway, :logger
 end

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -31,7 +31,8 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
   subject do
     described_class.new(
       stats_gateway: stats_gateway,
-      performance_gateway: performance_gateway
+      performance_gateway: performance_gateway,
+      logger: double(info: '')
     )
   end
 


### PR DESCRIPTION
We use Rake tasks which don't have access to the Rack logger, so we use
the logger from the Ruby standard library.

This is so we can have better visibility over what the rake tasks are
doing.

Unlike the Rack logger, we cannot switch this off in the test
environment with a configuration.  Pull out the dependency on the
logger, and inject a fake during testing.