### PR TITLE
Use different count key names on unique users periods

### DIFF
--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -11,7 +11,7 @@ class PerformancePlatform::Presenter::UniqueUsers
           _timestamp: timestamp,
           dataType: stats[:metric_name],
           period: stats[:period],
-          count: stats[:count]
+          count_field_name => stats[:count]
         }
       ]
     }
@@ -32,6 +32,10 @@ private
         stats[:metric_name]
       ]
     )
+  end
+
+  def count_field_name
+    stats[:period] == 'month' ? 'month_count' : 'count'
   end
 
   attr_reader :stats, :timestamp

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -153,7 +153,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
               _timestamp: '2018-07-16T00:00:00+00:00',
               dataType: 'unique-users',
               period: 'month',
-              count: 12345
+              month_count: 12345
             }
           ]
         }


### PR DESCRIPTION
Different periods on unique-users statistics for Performance
platform use different key names.