### PR TITLE
Fetch ip-location mapping from s3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ARG BUNDLE_INSTALL_CMD
 
 ENV S3_PUBLISHED_LOCATIONS_IPS_BUCKET 'stub-bucket'
 ENV S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY 'stub-key'
-ENV ACCESS_KEY_ID 'stub-access-key'
-ENV SECRET_ACCESS_KEY 'stub-secret-access-key'
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ruby:2.5-alpine
 ARG BUNDLE_INSTALL_CMD
 
+ENV S3_PUBLISHED_LOCATIONS_IPS_BUCKET 'stub-bucket'
+ENV S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY 'stub-key'
+
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG BUNDLE_INSTALL_CMD
 
 ENV S3_PUBLISHED_LOCATIONS_IPS_BUCKET 'stub-bucket'
 ENV S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY 'stub-key'
+ENV ACCESS_KEY_ID 'stub-access-key'
+ENV SECRET_ACCESS_KEY 'stub-secret-access-key'
 
 WORKDIR /usr/src/app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
+gem 'aws-sdk-s3', '~> 1'
 gem 'mysql2'
 gem 'puma'
 gem 'rake', '~> 12.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,21 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.104.0)
+    aws-sdk-core (3.27.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.9.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.19.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     backports (3.11.3)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -24,6 +39,7 @@ GEM
     hashdiff (0.3.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -109,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   govuk-lint
   mysql2
   puma
@@ -127,4 +144,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -1,4 +1,22 @@
+require 'aws-sdk-s3'
+
 class PerformancePlatform::Gateway::S3IpLocations
-  def fetch
+  def initialize
+    @s3 = Aws::S3::Client.new(config)
   end
+
+  def fetch
+    resp = s3.get_object(bucket: 'bucket-name', key: 'object-key')
+    resp.body.read
+  end
+
+private
+
+    DEFAULT_REGION = 'eu-west-2'.freeze
+
+    def config
+      { region: DEFAULT_REGION }
+    end
+
+  attr_reader :s3
 end

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -6,7 +6,10 @@ class PerformancePlatform::Gateway::S3IpLocations
   end
 
   def fetch
-    resp = s3.get_object(bucket: 'bucket-name', key: 'object-key')
+    bucket = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_BUCKET')
+    key = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY')
+
+    resp = s3.get_object(bucket: bucket, key: key)
     resp.body.read
   end
 
@@ -15,7 +18,11 @@ private
     DEFAULT_REGION = 'eu-west-2'.freeze
 
     def config
-      { region: DEFAULT_REGION }
+      {
+        region: DEFAULT_REGION,
+        access_key_id: 'ACCESS_KEY_ID',
+        secret_access_key: 'SECRET_ACCESS_KEY'
+      }
     end
 
   attr_reader :s3

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -2,27 +2,18 @@ require 'aws-sdk-s3'
 
 class PerformancePlatform::Gateway::S3IpLocations
   def initialize
-    @s3 = Aws::S3::Client.new(config)
+    @s3 = Aws::S3::Client.new(region: 'eu-west-2')
   end
 
   def fetch
     bucket = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_BUCKET')
     key = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY')
 
-    resp = s3.get_object(bucket: bucket, key: key)
-    JSON.parse(resp.body.read)
+    response = s3.get_object(bucket: bucket, key: key)
+    JSON.parse(response.body.read)
   end
 
 private
-
-  def config
-    {
-      region: 'eu-west-2',
-      access_key_id: ENV.fetch('ACCESS_KEY_ID'),
-      secret_access_key: ENV.fetch('SECRET_ACCESS_KEY'),
-      stub_responses: ENV.fetch('RACK_ENV') == 'development'
-    }
-  end
 
   attr_reader :s3
 end

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -10,20 +10,19 @@ class PerformancePlatform::Gateway::S3IpLocations
     key = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY')
 
     resp = s3.get_object(bucket: bucket, key: key)
-    resp.body.read
+    JSON.parse(resp.body.read)
   end
 
 private
 
-    DEFAULT_REGION = 'eu-west-2'.freeze
-
-    def config
-      {
-        region: DEFAULT_REGION,
-        access_key_id: 'ACCESS_KEY_ID',
-        secret_access_key: 'SECRET_ACCESS_KEY'
-      }
-    end
+  def config
+    {
+      region: 'eu-west-2',
+      access_key_id: ENV.fetch('ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('SECRET_ACCESS_KEY'),
+      stub_responses: ENV.fetch('RACK_ENV') == 'development'
+    }
+  end
 
   attr_reader :s3
 end

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -1,0 +1,4 @@
+class PerformancePlatform::Gateway::S3IpLocations
+  def fetch
+  end
+end

--- a/lib/performance_platform/gateway/sequel_ip_locations.rb
+++ b/lib/performance_platform/gateway/sequel_ip_locations.rb
@@ -2,9 +2,11 @@ class PerformancePlatform::Gateway::SequelIPLocations
   def save(ip_locations)
     truncate_ip_locations
 
-    ip_locations.each do |loc|
-      DB[:ip_locations].insert(ip: loc[:ip], location_id: loc[:location_ip])
+    data = ip_locations.map do |ip_location|
+      [ ip_location["ip"], ip_location["location_id"] ]
     end
+
+    DB[:ip_locations].import([:ip, :location_id], data)
   end
 
 private

--- a/lib/performance_platform/gateway/sequel_ip_locations.rb
+++ b/lib/performance_platform/gateway/sequel_ip_locations.rb
@@ -1,0 +1,11 @@
+class PerformancePlatform::Gateway::SequelIPLocations
+  def save(ip_locations)
+    truncate_ip_locations
+  end
+
+private
+
+  def truncate_ip_locations
+    DB[:ip_locations].truncate
+  end
+end

--- a/lib/performance_platform/gateway/sequel_ip_locations.rb
+++ b/lib/performance_platform/gateway/sequel_ip_locations.rb
@@ -1,6 +1,10 @@
 class PerformancePlatform::Gateway::SequelIPLocations
   def save(ip_locations)
     truncate_ip_locations
+
+    ip_locations.each do |loc|
+      DB[:ip_locations].insert(ip: loc[:ip], location_id: loc[:location_ip])
+    end
   end
 
 private

--- a/lib/performance_platform/gateway/sequel_ip_locations.rb
+++ b/lib/performance_platform/gateway/sequel_ip_locations.rb
@@ -3,10 +3,10 @@ class PerformancePlatform::Gateway::SequelIPLocations
     truncate_ip_locations
 
     data = ip_locations.map do |ip_location|
-      [ ip_location["ip"], ip_location["location_id"] ]
+      [ip_location['ip'], ip_location['location_id']]
     end
 
-    DB[:ip_locations].import([:ip, :location_id], data)
+    DB[:ip_locations].import(%i[ip location_id], data)
   end
 
 private

--- a/lib/performance_platform/use_case/synchronize_ip_locations.rb
+++ b/lib/performance_platform/use_case/synchronize_ip_locations.rb
@@ -1,0 +1,15 @@
+class PerformancePlatform::UseCase::SynchronizeIpLocations
+  def initialize(source_gateway:, destination_gateway:)
+    @source_gateway = source_gateway
+    @destination_gateway = destination_gateway
+  end
+
+  def execute
+    results = source_gateway.fetch
+    destination_gateway.save(results)
+  end
+
+private
+
+  attr_reader :source_gateway, :destination_gateway
+end

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -45,6 +45,11 @@ CREATE TABLE `sessions` (
   KEY `sessions_start_username` (`start`,`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `ip_locations` (
+  `ip` varchar(30) DEFAULT NULL,
+  `location_id` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 
 --
 -- Table structure for table `site`

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -5,11 +5,11 @@ describe 'synchronizing IPs and locations' do
     ENV['S3_PUBLISHED_LOCATIONS_IPS_BUCKET'] = 'stub-bucket'
     ENV['S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY'] = 'stub-key'
 
-    stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
-      .to_return(body: '')
-
-    stub_request(:get, 'https://stub-bucket.s3.eu-west-2.amazonaws.com/stub-key') \
-      .to_return(body: object_content.to_json)
+    Aws.config = {
+      stub_responses: {
+        get_object: { body: object_content.to_json }
+      }
+    }
 
     ip_locations.truncate
   end

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -1,8 +1,7 @@
-require 'rake'
-require_relative '../../tasks/publish_statistics'
-
 describe 'synchronizing IPs and locations' do
-  before { DB[:ip_locations].truncate }
+  let(:ip_locations) { DB[:ip_locations] }
+
+  before { ip_locations.truncate }
 
   subject do
     source_gateway = PerformancePlatform::Gateway::S3IpLocations.new
@@ -15,14 +14,35 @@ describe 'synchronizing IPs and locations' do
 
   it 'saves empty IPs and locations' do
     subject.execute
-    expect(DB[:ip_locations].count).to be_zero
+    expect(ip_locations.count).to be_zero
   end
 
   context 'with existing IPs and locations in the database' do
+    before { ip_locations.insert(ip: 1, location_id: 1) }
+
     it 'overwrites them' do
-      DB[:ip_locations].insert(ip: 1, location_id: 1)
       subject.execute
-      expect(DB[:ip_locations].count).to be_zero
+      expect(ip_locations.count).to be_zero
+    end
+  end
+
+  xcontext 'three IPs and locations are in source' do
+    before do
+      # webmock s3 here?
+    end
+
+    it 'saves three IPs and locations' do
+      subject.execute
+      expect(ip_locations.count).to be_zero
+    end
+
+    context 'with existing IPs and locations in the database' do
+      before { ip_locations.insert(ip: 1, location_id: 1) }
+
+      it 'overwrites them instead of adding to them' do
+        subject.execute
+        expect(ip_locations.count).to eq 3
+      end
     end
   end
 end

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -26,18 +26,47 @@ describe 'synchronizing IPs and locations' do
     end
   end
 
-  xcontext 'three IPs and locations are in source' do
+  context 'three IPs and locations are in source' do
+    let(:object_content) do
+      [
+        {
+          ip: '127.0.0.1',
+          location_id: 1
+        }, {
+          ip: '186.3.1.1',
+          location_id: 2
+        }, {
+          ip: '186.3.4.6',
+          location_id: 3
+        }
+      ]
+    end
+
+    let(:bucket) { 'StubBucket' }
+    let(:key) { 'StubKey' }
+
     before do
-      # webmock s3 here?
+      ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/stubUri'
+
+      stub_request(:get, 'http://169.254.170.2/stubUri').to_return(body: {
+        'AccessKeyId': 'ACCESS_KEY_ID',
+        'Expiration': (Time.now + 60).iso8601,
+        'RoleArn': 'TASK_ROLE_ARN',
+        'SecretAccessKey': 'SECRET_ACCESS_KEY',
+        'Token': 'SECURITY_TOKEN_STRING'
+      }.to_json)
+
+      stub_request(:get, 'https://s3.eu-west-1.amazonaws.com/#{bucket}/#{key}') \
+        .to_return(body: object_content.to_json)
     end
 
     it 'saves three IPs and locations' do
       subject.execute
-      expect(ip_locations.count).to be_zero
+      expect(ip_locations.count).to eq(3)
     end
 
     context 'with existing IPs and locations in the database' do
-      before { ip_locations.insert(ip: 1, location_id: 1) }
+      before { ip_locations.insert(ip: '186.3.1.1', location_id: 1) }
 
       it 'overwrites them instead of adding to them' do
         subject.execute

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -1,26 +1,28 @@
 require 'rake'
 require_relative '../../tasks/publish_statistics'
 
-xdescribe 'synchronizing IPs and locations' do
-  let(:ip_locations_table) { DB[:ip_locations] }
+describe 'synchronizing IPs and locations' do
+  before { DB[:ip_locations].truncate }
 
-  before { ip_locations_table.truncate }
-
-  context 'with none in the database' do
-    it 'persists empty IPs and locations' do
-      Rake::Task['synchronize_ip_locations'].invoke
-      expect(ip_locations_table.count).to be_zero
-    end
+  subject do
+    source_gateway = PerformancePlatform::Gateway::S3IpLocations.new
+    destination_gateway = PerformancePlatform::Gateway::SequelIPLocations.new
+    PerformancePlatform::UseCase::SynchronizeIpLocations.new(
+      source_gateway: source_gateway,
+      destination_gateway: destination_gateway
+    )
   end
 
-  context 'with one in the database' do
-    before do
-      ip_locations_table.insert(ip: 1,location_id: 1)
-    end
+  it 'saves empty IPs and locations' do
+    subject.execute
+    expect(DB[:ip_locations].count).to be_zero
+  end
 
-    it 'persists empty IPs and locations' do
-      Rake::Task['synchronize_ip_locations'].invoke
-      expect(ip_locations_table.count).to be_zero
+  context 'with existing IPs and locations in the database' do
+    it 'overwrites them' do
+      DB[:ip_locations].insert(ip: 1, location_id: 1)
+      subject.execute
+      expect(DB[:ip_locations].count).to be_zero
     end
   end
 end

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -1,0 +1,26 @@
+require 'rake'
+require_relative '../../tasks/publish_statistics'
+
+xdescribe 'synchronizing IPs and locations' do
+  let(:ip_locations_table) { DB[:ip_locations] }
+
+  before { ip_locations_table.truncate }
+
+  context 'with none in the database' do
+    it 'persists empty IPs and locations' do
+      Rake::Task['synchronize_ip_locations'].invoke
+      expect(ip_locations_table.count).to be_zero
+    end
+  end
+
+  context 'with one in the database' do
+    before do
+      ip_locations_table.insert(ip: 1,location_id: 1)
+    end
+
+    it 'persists empty IPs and locations' do
+      Rake::Task['synchronize_ip_locations'].invoke
+      expect(ip_locations_table.count).to be_zero
+    end
+  end
+end

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -1,0 +1,34 @@
+describe PerformancePlatform::Gateway::SequelIPLocations do
+  let(:locations) { DB[:ip_locations] }
+
+  before { subject.save(data) }
+
+  context 'with no data' do
+    let(:data) { [] }
+
+    it 'saves no ip/locations' do
+      expect(locations.count).to be_zero
+    end
+  end
+
+  context 'with three ip/locations' do
+    let(:data) do
+      [
+        {
+          ip: '127.0.0.1',
+          location_id: 1
+        }, {
+          ip: '186.3.1.1',
+          location_id: 2
+        }, {
+          ip: '186.3.4.6',
+          location_id: 3
+        }
+      ]
+    end
+
+    it 'saves those ip/locations' do
+      expect(locations.count).to eq(3)
+    end
+  end
+end

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -1,0 +1,38 @@
+describe PerformancePlatform::UseCase::SynchronizeIpLocations do
+  subject do
+    described_class.new(
+      source_gateway: source_gateway,
+      destination_gateway: destination_gateway
+    )
+  end
+
+  let(:source_gateway) { double(fetch: nil) }
+  let(:destination_gateway) { double(save: nil) }
+
+  before { subject.execute }
+
+  it 'fetches from the source gateway' do
+    expect(source_gateway).to have_received(:fetch)
+  end
+
+  it 'writes to the destination gateway' do
+    expect(destination_gateway).to have_received(:save)
+  end
+
+  context 'given results from the source gateway' do
+    let(:results) do
+      [
+        {
+          ip: '127.0.0.1',
+          location_id: 1
+        }
+      ]
+    end
+
+    let(:source_gateway) { double(fetch: results) }
+
+    it 'passes results to the destination gateway' do
+      expect(destination_gateway).to have_received(:save).with(results)
+    end
+  end
+end

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -6,6 +6,10 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
     )
   end
 
+  after do
+    DB[:ip_locations].truncate
+  end
+
   let(:source_gateway) { double(fetch: nil) }
   let(:destination_gateway) { double(save: nil) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,14 +6,6 @@ require 'timecop'
 
 ENV['RACK_ENV'] = 'test'
 
-DB = Sequel.connect(
-  adapter: 'mysql2',
-  host: ENV.fetch('DB_HOSTNAME'),
-  database: ENV.fetch('DB_NAME'),
-  user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS')
-)
-
 require File.expand_path '../../app.rb', __FILE__
 
 module RSpecMixin

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -2,7 +2,12 @@ require 'logger'
 logger = Logger.new(STDOUT)
 
 task :synchronize_ip_locations do
-  PerformancePlatform::UseCase::SynchronizeIpLocations.new.execute
+  source_gateway = PerformancePlatform::Gateway::S3IpLocations.new
+  destination_gateway = PerformancePlatform::Gateway::SequelIPLocations.new
+  PerformancePlatform::UseCase::SynchronizeIpLocations.new(
+    source_gateway: source_gateway,
+    destination_gateway: destination_gateway
+  ).execute
 end
 
 task :publish_daily_statistics do

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -1,6 +1,10 @@
 require 'logger'
 logger = Logger.new(STDOUT)
 
+task :synchronize_ip_locations do
+  PerformancePlatform::UseCase::SynchronizeIpLocations.new.execute
+end
+
 task :publish_daily_statistics do
   logger.info('Publishing daily statistics')
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new


### PR DESCRIPTION
This PR fetches mappings (of the form { ip: '123.123.123.123', location_id: '1' }) from the configured s3 bucket, and saves them to the `ip_locations` table.

This use case is used by the `synchronize_ip_locations` rake task, which'll be called before we `publish_daily_statistics`. 

This means we can properly identify which requests are users roaming between different locations.

Not locally tested yet, and a few bits I'm less happy with and want input on.