### PR TITLE
Change source table for roaming 'account usage'

### DIFF
--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -2,17 +2,19 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
   dataset_module do
     def account_usage_stats(*)
       DB.fetch("
-       SELECT
-         count(distinct(username)) as total,
-         count(distinct(concat_ws('-', sessions.username, site.address))) as per_site
-         FROM sessions
-         LEFT JOIN siteip
-         ON (siteip.ip = sessions.siteIP)
-         LEFT JOIN site
-         ON (siteip.site_id = site.id)
-           WHERE site.org_id IS NOT NULL
-           AND date(sessions.start) = '#{Date.today - 1}'
-      GROUP BY date(start)").first
+        SELECT
+          count(distinct(username)) as total,
+          count(distinct(concat_ws('-', sessions.username, ip_locations.location_id))) as per_site
+        FROM
+          sessions
+          LEFT JOIN
+            ip_locations
+            ON
+            (ip_locations.ip = sessions.siteIP)
+        WHERE
+          date(sessions.start) = '#{Date.today - 1}'
+        GROUP BY
+            date(start)").first
     end
 
     def unique_users_stats(period:)

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -1,7 +1,6 @@
 describe PerformancePlatform::Gateway::AccountUsage do
   let(:sessions) { DB[:sessions] }
-  let(:locations) { DB[:site] }
-  let(:location_ip_links) { DB[:siteip] }
+  let(:location_ip_links) { DB[:ip_locations] }
 
   let(:ip_A1) { '104.24.112.118' }
   let(:ip_A2) { '104.24.112.120' }
@@ -14,16 +13,12 @@ describe PerformancePlatform::Gateway::AccountUsage do
 
   before do
     sessions.truncate
-    locations.truncate
     location_ip_links.truncate
 
-    location_a = locations.insert(address: 'House One', org_id: 1)
-    location_b = locations.insert(address: 'House Two', org_id: 1)
-
-    location_ip_links.insert(ip: ip_A1, site_id: location_a)
-    location_ip_links.insert(ip: ip_A2, site_id: location_a)
-    location_ip_links.insert(ip: ip_B1, site_id: location_b)
-    location_ip_links.insert(ip: ip_B2, site_id: location_b)
+    location_ip_links.insert(ip: ip_A1, location_id: 1)
+    location_ip_links.insert(ip: ip_A2, location_id: 1)
+    location_ip_links.insert(ip: ip_B1, location_id: 2)
+    location_ip_links.insert(ip: ip_B2, location_id: 2)
   end
 
   describe 'one user' do


### PR DESCRIPTION
This is the followup to #46.

This PR changes the expected data source for ip/location links when calculating 'account usage', from `site_ip` and `site` to just `ip_locations`.

(note that this PR doesn't point at master - this is for an easier diff, can change target once #46 is in)