### PR TITLE
Report errors to Sentry for failed Rake tasks

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,14 +1,4 @@
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
-if %w[production staging].include?(RACK_ENV)
-  require 'raven'
-
-  Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
-  end
-
-  use Raven::Rack
-end
-
 require './app'
 run App

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -13,6 +13,14 @@ DB = Sequel.connect(
   read_timeout: 9999
 )
 
+if %w[production staging].include?(ENV['RACK_ENV'])
+  require 'raven'
+
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+  end
+end
+
 module Common;
 end
 


### PR DESCRIPTION
We are getting no errors when these tasks fail.
This will report the errors to sentry.