### PR TITLE
Allow date overrides for rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ This is useful for debugging and populating last_login of the user.
 - Account Usage
 - Unique Users
 
+### Send statistics manually
+
+You can trigger statistics to be sent manually by running the command below locally.
+Ensure that your ~/.aws/credentials is set up correctly.
+Populate the date argument to the Rake task with the date that you want to send the statistics for.
+
+#### Account Usage
+
+```shell
+aws ecs run-task --cluster wifi-api-cluster --task-definition logging-api-task-wifi --count 1 --overrides "{ \"containerOverrides\": [{ \"name\": \"logging\", \"command\": [\"bundle\", \"exec\", \"rake\", \"publish_daily_statistics['2018-09-24']\"] }] }" --region eu-west-2
+```
+
+#### Unique Users
+
+```shell
+aws ecs run-task --cluster wifi-api-cluster --task-definition logging-api-task-wifi --count 1 --overrides "{ \"containerOverrides\": [{ \"name\": \"logging\", \"command\": [\"bundle\", \"exec\", \"rake\", \"publish_weekly_statistics['2018-09-24']\"] }] }" --region eu-west-2
+```
+
 ### Sinatra routes
 
 * `GET /healthcheck` - AWS ELB target group health checking

--- a/lib/performance_platform/gateway/account_usage.rb
+++ b/lib/performance_platform/gateway/account_usage.rb
@@ -1,10 +1,11 @@
 class PerformancePlatform::Gateway::AccountUsage
-  def initialize(period:)
+  def initialize(period:, date: Date.today.to_s)
     @period = period
+    @date = Date.parse(date)
   end
 
   def fetch_stats
-    result = repository.account_usage_stats(period: period) || Hash.new(0)
+    result = repository.account_usage_stats(date) || Hash.new(0)
 
     {
       total: result[:total].to_i,
@@ -22,5 +23,5 @@ private
     PerformancePlatform::Repository::Session
   end
 
-  attr_reader :period
+  attr_reader :period, :date
 end

--- a/lib/performance_platform/gateway/unique_users.rb
+++ b/lib/performance_platform/gateway/unique_users.rb
@@ -1,6 +1,7 @@
 class PerformancePlatform::Gateway::UniqueUsers
-  def initialize(period:)
+  def initialize(period:, date: Date.today.to_s)
     @period = period.to_s
+    @date = Date.parse(date)
   end
 
   def fetch_stats
@@ -18,8 +19,8 @@ private
   end
 
   def result
-    repository.unique_users_stats(period: period) || Hash.new(0)
+    repository.unique_users_stats(period: period, date: date) || Hash.new(0)
   end
 
-  attr_reader :period
+  attr_reader :period, :date
 end

--- a/lib/performance_platform/presenter/account_usage.rb
+++ b/lib/performance_platform/presenter/account_usage.rb
@@ -1,7 +1,8 @@
 class PerformancePlatform::Presenter::AccountUsage
-  def present(stats:)
+  def present(stats:, date: Date.today.to_s)
     @stats = stats
     @timestamp = generate_timestamp
+    @date = Date.parse(date)
 
     {
       metric_name: stats[:metric_name],
@@ -17,7 +18,7 @@ class PerformancePlatform::Presenter::AccountUsage
 private
 
   def generate_timestamp
-    "#{Date.today - 1}T00:00:00+00:00"
+    "#{date - 1}T00:00:00+00:00"
   end
 
   def as_hash(count, type)
@@ -43,5 +44,5 @@ private
     )
   end
 
-  attr_reader :stats, :timestamp
+  attr_reader :stats, :timestamp, :date
 end

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -1,7 +1,8 @@
 class PerformancePlatform::Presenter::UniqueUsers
-  def present(stats:)
+  def present(stats:, date: Date.today.to_s)
     @stats = stats
     @timestamp = generate_timestamp
+    @date = date
 
     {
       metric_name: stats[:metric_name],
@@ -20,7 +21,7 @@ class PerformancePlatform::Presenter::UniqueUsers
 private
 
   def generate_timestamp
-    "#{Date.today - 1}T00:00:00+00:00"
+    "#{date - 1}T00:00:00+00:00"
   end
 
   def encode_id
@@ -38,5 +39,5 @@ private
     stats[:period] == 'month' ? 'month_count' : 'count'
   end
 
-  attr_reader :stats, :timestamp
+  attr_reader :stats, :timestamp, :date
 end

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,6 +1,6 @@
 class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
   dataset_module do
-    def account_usage_stats(*)
+    def account_usage_stats(date)
       DB.fetch("
         SELECT
           count(distinct(username)) as total,
@@ -12,16 +12,16 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
             ON
             (ip_locations.ip = sessions.siteIP)
         WHERE
-          date(sessions.start) = '#{Date.today - 1}'
+          date(sessions.start) = '#{date - 1}'
         GROUP BY
             date(start)").first
     end
 
-    def unique_users_stats(period:)
+    def unique_users_stats(period:, date:)
       sql = "SELECT sum(users)/count(*) DIV 1 as `count`
       FROM (SELECT date(start) AS day, count(distinct(username)) AS users
-      FROM sessions WHERE start BETWEEN date_sub('#{Date.today}', INTERVAL 1 #{period})
-      AND '#{Date.today}' AND dayofweek(start) NOT IN (1,7) GROUP BY day) foo;"
+      FROM sessions WHERE start BETWEEN date_sub('#{date}', INTERVAL 1 #{period})
+      AND '#{date}' AND dayofweek(start) NOT IN (1,7) GROUP BY day) foo;"
 
       DB.fetch(sql).first
     end

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -219,4 +219,33 @@ describe PerformancePlatform::Gateway::AccountUsage do
       )
     end
   end
+
+  context 'Date override' do
+    subject { described_class.new(period: 'day', date: '2018-07-10') }
+
+    before do
+      sessions.insert(
+        siteIP: 'Email',
+        username: 'xyz123',
+        start: '2018-07-09'
+      )
+
+      sessions.insert(
+        siteIP: 'Email',
+        username: 'abc987',
+        start: '2018-08-09'
+      )
+    end
+
+    it 'counts both of them to cumulative number of sponsored sign ups' do
+      expect(subject.fetch_stats).to eq(
+        total: 1,
+        transactions: 1,
+        roaming: 0,
+        one_time: 1,
+        metric_name: 'account-usage',
+        period: 'day',
+      )
+    end
+  end
 end

--- a/spec/lib/performance_platform/gateway/unique_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/unique_users_spec.rb
@@ -129,5 +129,29 @@ describe PerformancePlatform::Gateway::UniqueUsers do
         )
       end
     end
+
+    context 'Date override' do
+      subject { described_class.new(period: 'week', date: '2018-07-10') }
+
+      before do
+        session_repository.insert(
+          username: 'xyz123',
+          start: '2018-07-09'
+        )
+
+        session_repository.insert(
+          username: 'abc987',
+          start: '2018-08-09'
+        )
+      end
+
+      it 'uses the date argument' do
+        expect(subject.fetch_stats).to eq(
+          count: 1,
+          metric_name: 'unique-users',
+          period: 'week',
+        )
+      end
+    end
   end
 end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -10,11 +10,12 @@ task :synchronize_ip_locations do
   ).execute
 end
 
-task publish_daily_statistics: [:synchronize_ip_locations] do
-  logger.info('Publishing daily statistics')
+task :publish_daily_statistics, [:date] => [:synchronize_ip_locations] do |_, args|
+  args.with_defaults(date: Date.today.to_s)
+  logger.info("Publishing daily statistics with #{args}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
-  account_usage_gateway = PerformancePlatform::Gateway::AccountUsage.new(period: 'day')
-  account_usage_presenter = PerformancePlatform::Presenter::AccountUsage.new
+  account_usage_gateway = PerformancePlatform::Gateway::AccountUsage.new(period: 'day', date: date)
+  account_usage_presenter = PerformancePlatform::Presenter::AccountUsage.new(date: date)
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: account_usage_gateway,
@@ -22,11 +23,11 @@ task publish_daily_statistics: [:synchronize_ip_locations] do
   ).execute(presenter: account_usage_presenter)
 end
 
-task :publish_weekly_statistics do
-  logger.info('Publishing weekly statistics')
+task :publish_weekly_statistics, [:date] do |_, args|
+  logger.info("Publishing weekly statistics with #{args}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
-  unique_users_gateway = PerformancePlatform::Gateway::UniqueUsers.new(period: 'week')
-  unique_users_presenter = PerformancePlatform::Presenter::UniqueUsers.new
+  unique_users_gateway = PerformancePlatform::Gateway::UniqueUsers.new(period: 'week', date: date)
+  unique_users_presenter = PerformancePlatform::Presenter::UniqueUsers.new(date: date)
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: unique_users_gateway,
@@ -34,11 +35,11 @@ task :publish_weekly_statistics do
   ).execute(presenter: unique_users_presenter)
 end
 
-task :publish_monthly_statistics do
-  logger.info('Publishing monthly statistics')
+task :publish_monthly_statistics, [:date] do |_, args|
+  logger.info("Publishing monthly statistics with #{args}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
-  unique_users_gateway = PerformancePlatform::Gateway::UniqueUsers.new(period: 'month')
-  unique_users_presenter = PerformancePlatform::Presenter::UniqueUsers.new
+  unique_users_gateway = PerformancePlatform::Gateway::UniqueUsers.new(period: 'month', date: date)
+  unique_users_presenter = PerformancePlatform::Presenter::UniqueUsers.new(date: date)
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: unique_users_gateway,


### PR DESCRIPTION
We are seeing gaps in our performance platform statistics, we are unable
to find the root cause of this.

Allow overriding the date to backfill missing data for now