### PR TITLE
Kill docker containers every CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,9 @@ pipeline {
     success {
       setBuildStatus("Build successful", "SUCCESS");
     }
+    cleanup {
+      sh 'make stop'
+    }
   }
 }
 


### PR DESCRIPTION
We've had some "hanging" docker containers on Jenkins that block
other builds - this PR makes sure `make stop` is always run, even in
cases of the build being aborted or crashing.