### PR TITLE
Search authentication events by username endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,7 +17,8 @@ class App < Sinatra::Base
 
   get '/authentication/events/search/:username' do
     username = params[:username]
-    sessions = Session.where(username: username).reverse_order(:start).limit(100)
+    two_weeks_ago = Time.now - 2 * 7 * 24 * 60 * 60
+    sessions = Session.where(username: username).where { start > two_weeks_ago }
 
     json sessions.map(&:to_hash)
   end

--- a/app.rb
+++ b/app.rb
@@ -1,14 +1,30 @@
+# frozen_string_literal: true
+
 require 'sequel'
 require 'sinatra/base'
+require 'sinatra/json'
 require './lib/loader'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do
     enable :logging
+    enable :json
   end
 
   get '/healthcheck' do
     'Healthy'
+  end
+
+  get '/authentication/events/search/:username' do
+    username = params[:username]
+
+    if Session.all.length == 0
+      json []
+    else
+      sessions = Session.where(username: username).all
+
+      json sessions.map { |s| { username: s[:username] } }
+    end
   end
 
   get '/logging/post-auth/user/?:username?/mac/?:mac?/ap/?:called_station_id?/site/?:site_ip_address?/result/:authentication_result' do

--- a/app.rb
+++ b/app.rb
@@ -17,14 +17,9 @@ class App < Sinatra::Base
 
   get '/authentication/events/search/:username' do
     username = params[:username]
+    sessions = Session.where(username: username).reverse_order(:start).limit(100)
 
-    if Session.all.length == 0
-      json []
-    else
-      sessions = Session.where(username: username).all
-
-      json sessions.map { |s| { username: s[:username] } }
-    end
+    json sessions.map(&:to_hash)
   end
 
   get '/logging/post-auth/user/?:username?/mac/?:mac?/ap/?:called_station_id?/site/?:site_ip_address?/result/:authentication_result' do

--- a/spec/features/search_sessions_spec.rb
+++ b/spec/features/search_sessions_spec.rb
@@ -35,14 +35,14 @@ describe App do
         expect(JSON.parse(last_response.body)).to eq(
           [
             {
-              "ap"=>"",
-              "building_identifier"=>"",
-              "id"=>1,
-              "mac"=>"",
-              "siteIP"=>"",
-              "start"=>"2018-10-01 18:18:09 +0000",
-              "stop"=>nil,
-              "username"=>"VYKZDK"
+              "ap" => "",
+              "building_identifier" => "",
+              "id" => 1,
+              "mac" => "",
+              "siteIP" => "",
+              "start" => "2018-10-01 18:18:09 +0000",
+              "stop" => nil,
+              "username" => "VYKZDK"
             }
           ]
         )
@@ -73,8 +73,9 @@ describe App do
         get '/authentication/events/search/ZZZZZZ'
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body).length).to eq(1)
-        expect(JSON.parse(last_response.body).first['username']).to eq('ZZZZZZ')
+        json_response = JSON.parse(last_response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response.first['username']).to eq('ZZZZZZ')
       end
     end
 
@@ -107,8 +108,9 @@ describe App do
         get '/authentication/events/search/VYKZDK'
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body).length).to eq(100)
-        unique_dates = JSON.parse(last_response.body).map{|session| session['start']}.uniq
+        json_response = JSON.parse(last_response.body)
+        expect(json_response.length).to eq(100)
+        unique_dates = json_response.map { |session| session['start'] }.uniq
         expect(unique_dates.length).to eq(1)
         expect(unique_dates.first).to eq('2018-01-01 00:00:01 +0000')
       end

--- a/spec/features/search_sessions_spec.rb
+++ b/spec/features/search_sessions_spec.rb
@@ -111,8 +111,7 @@ describe App do
         json_response = JSON.parse(last_response.body)
         expect(json_response.length).to eq(100)
         unique_dates = json_response.map { |session| session['start'] }.uniq
-        expect(unique_dates.length).to eq(1)
-        expect(unique_dates.first).to eq('2018-01-01 00:00:01 +0000')
+        expect(unique_dates).to eq(['2018-01-01 00:00:01 +0000'])
       end
     end
   end

--- a/spec/features/search_sessions_spec.rb
+++ b/spec/features/search_sessions_spec.rb
@@ -24,6 +24,7 @@ describe App do
           mac: '',
           ap: '',
           siteIP: '',
+          success: true,
           building_identifier: ''
         )
       end
@@ -42,6 +43,7 @@ describe App do
               "siteIP" => "",
               "start" => "2018-10-01 18:18:09 +0000",
               "stop" => nil,
+              "success" => true,
               "username" => "VYKZDK"
             }
           ]
@@ -57,6 +59,7 @@ describe App do
           mac: '',
           ap: '',
           siteIP: '',
+          success: true,
           building_identifier: ''
         )
         Session.create(
@@ -65,6 +68,7 @@ describe App do
           mac: '',
           ap: '',
           siteIP: '',
+          success: true,
           building_identifier: ''
         )
       end
@@ -88,6 +92,7 @@ describe App do
             mac: '',
             ap: '',
             siteIP: '',
+            success: true,
             building_identifier: ''
           )
         end
@@ -99,6 +104,7 @@ describe App do
             mac: '',
             ap: '',
             siteIP: '',
+            success: true,
             building_identifier: ''
           )
         end

--- a/spec/features/search_sessions_spec.rb
+++ b/spec/features/search_sessions_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe App do
+  before do
+    DB[:sessions].truncate
+    DB[:userdetails].truncate
+  end
+
+  describe 'GET /authentication/events/search' do
+    context 'given no sessions for any user' do
+      it 'can retrieve no events' do
+        get '/authentication/events/search/aaaaaa'
+
+        expect(JSON.parse(last_response.body)).to eq([])
+      end
+    end
+
+    context 'given one session for a user' do
+      before do
+        Session.create(
+          start: Time.now,
+          username: 'VYKZDK',
+          mac: '',
+          ap: '',
+          siteIP: '',
+          building_identifier: ''
+        )
+      end
+
+      it 'can retrieve the users event' do
+        get '/authentication/events/search/VYKZDK'
+
+        expect(JSON.parse(last_response.body)).to eq([{'username' => 'VYKZDK'}])
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    context 'given one session for two users' do
+      before do
+        Session.create(
+          start: Time.now,
+          username: 'VYKZDK',
+          mac: '',
+          ap: '',
+          siteIP: '',
+          building_identifier: ''
+        )
+        Session.create(
+          start: Time.now,
+          username: 'ZZZZZZ',
+          mac: '',
+          ap: '',
+          siteIP: '',
+          building_identifier: ''
+        )
+      end
+
+      it 'can retrieve the correct users event' do
+        get '/authentication/events/search/ZZZZZZ'
+
+        expect(JSON.parse(last_response.body)).to eq([{'username' => 'ZZZZZZ'}])
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/features/search_sessions_spec.rb
+++ b/spec/features/search_sessions_spec.rb
@@ -11,6 +11,7 @@ describe App do
       it 'can retrieve no events' do
         get '/authentication/events/search/aaaaaa'
 
+        expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)).to eq([])
       end
     end
@@ -18,7 +19,7 @@ describe App do
     context 'given one session for a user' do
       before do
         Session.create(
-          start: Time.now,
+          start: "2018-10-01 18:18:09 +0000",
           username: 'VYKZDK',
           mac: '',
           ap: '',
@@ -30,8 +31,21 @@ describe App do
       it 'can retrieve the users event' do
         get '/authentication/events/search/VYKZDK'
 
-        expect(JSON.parse(last_response.body)).to eq([{'username' => 'VYKZDK'}])
         expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq(
+          [
+            {
+              "ap"=>"",
+              "building_identifier"=>"",
+              "id"=>1,
+              "mac"=>"",
+              "siteIP"=>"",
+              "start"=>"2018-10-01 18:18:09 +0000",
+              "stop"=>nil,
+              "username"=>"VYKZDK"
+            }
+          ]
+        )
       end
     end
 
@@ -58,8 +72,45 @@ describe App do
       it 'can retrieve the correct users event' do
         get '/authentication/events/search/ZZZZZZ'
 
-        expect(JSON.parse(last_response.body)).to eq([{'username' => 'ZZZZZZ'}])
         expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body).length).to eq(1)
+        expect(JSON.parse(last_response.body).first['username']).to eq('ZZZZZZ')
+      end
+    end
+
+    context 'given more than one hundred sessions for a user' do
+      before do
+        100.times do
+          Session.create(
+            start: "2018-01-01 00:00:01 +0000",
+            username: 'VYKZDK',
+            mac: '',
+            ap: '',
+            siteIP: '',
+            building_identifier: ''
+          )
+        end
+
+        2.times do
+          Session.create(
+            start: "2000-01-01 00:00:01 +0000",
+            username: 'VYKZDK',
+            mac: '',
+            ap: '',
+            siteIP: '',
+            building_identifier: ''
+          )
+        end
+      end
+
+      it 'returns only the most recent 100 events' do
+        get '/authentication/events/search/VYKZDK'
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body).length).to eq(100)
+        unique_dates = JSON.parse(last_response.body).map{|session| session['start']}.uniq
+        expect(unique_dates.length).to eq(1)
+        expect(unique_dates.first).to eq('2018-01-01 00:00:01 +0000')
       end
     end
   end


### PR DESCRIPTION
- Exposes a GET '/authentication/events/search/:username' endpoint
- This endpoint will be queried by the Admin rails app for user logs.
- Limits search to last 100 sessions. This is just a finger in the air guess at what is an appropriate rate limit.
- Has no limitation on what location these sessions were created from. The Admin portal will be responsible for any kind of filtering based on permissions / ownership of data / IPs / Locations etc.