### PR TITLE
Log data for 'access-reject' auth requests

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -1,28 +1,25 @@
 module Logging
   class PostAuth
     def execute(params:)
-      authentication_result = params.fetch(:authentication_result)
-
-      if authentication_result == 'Access-Accept'
-        handle_access_accept(params)
-        return true
-      elsif authentication_result == 'Access-Reject'
-        return true
-      end
-
-      false
+      valid_request?(params) ? handle_access_request(params) : false
     end
 
   private
 
     VALID_MAC_LENGTH = 17
 
-    def handle_access_accept(params)
-      username = params.fetch(:username)
-      return if username == 'HEALTH'
+    def valid_request?(params)
+      valid_auth_results = ['Access-Accept', 'Access-Reject']
+      auth_result = params.fetch(:authentication_result)
+      valid_auth_results.include?(auth_result)
+    end
 
-      create_session(params)
+    def handle_access_request(params)
+      username = params.fetch(:username)
+      return true if username == 'HEALTH'
+
       update_user_last_login(username)
+      create_session(params)
     end
 
     def create_session(params)

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -1,44 +1,48 @@
 module Logging
   class PostAuth
     def execute(params:)
-      valid_request?(params) ? handle_access_request(params) : false
+      @params = params
+
+      return false unless access_accept? || access_reject?
+      return true if username == 'HEALTH'
+
+      update_user_last_login unless access_reject?
+      create_session
     end
 
   private
 
     VALID_MAC_LENGTH = 17
 
-    def valid_request?(params)
-      valid_auth_results = ['Access-Accept', 'Access-Reject']
-      auth_result = params.fetch(:authentication_result)
-      valid_auth_results.include?(auth_result)
-    end
-
-    def handle_access_request(params)
-      username = params.fetch(:username)
-      return true if username == 'HEALTH'
-
-      update_user_last_login(username)
-      create_session(params)
-    end
-
-    def create_session(params)
+    def create_session
       Session.create(
         start: Time.now,
-        username: username(params.fetch(:username)),
-        mac: formatted_mac(params.fetch(:mac)),
-        ap: ap(params.fetch(:called_station_id)),
-        siteIP: params.fetch(:site_ip_address),
-        building_identifier: building_identifier(params.fetch(:called_station_id))
+        username: username.to_s.upcase,
+        mac: formatted_mac(@params.fetch(:mac)),
+        ap: ap(@params.fetch(:called_station_id)),
+        siteIP: @params.fetch(:site_ip_address),
+        building_identifier: building_identifier(@params.fetch(:called_station_id))
       )
     end
 
-    def update_user_last_login(username)
+    def update_user_last_login
       user = User.find(username: username)
       return unless user
 
       user.last_login = Time.now
       user.save
+    end
+
+    def access_reject?
+      @params.fetch(:authentication_result) == 'Access-Reject'
+    end
+
+    def access_accept?
+      @params.fetch(:authentication_result) == 'Access-Accept'
+    end
+
+    def username
+      @params.fetch(:username)
     end
 
     def formatted_mac(unformatted_mac)
@@ -51,10 +55,6 @@ module Logging
 
     def building_identifier(called_station_id)
       called_station_id if !valid_mac?(formatted_mac(called_station_id))
-    end
-
-    def username(unformatted_username)
-      unformatted_username.to_s.upcase
     end
 
     def ap(unformatted_mac)

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -18,9 +18,7 @@ describe App do
       post_auth_request
     end
 
-    context 'Access-Accept' do
-      let(:authentication_result) { 'Access-Accept' }
-
+    shared_examples 'it saves the right logging information' do
       context 'GovWifi user' do
         it 'creates a single session record' do
           expect(Session.count).to eq(1)
@@ -129,21 +127,16 @@ describe App do
       end
     end
 
+    context 'Access-Accept' do
+      let(:authentication_result) { 'Access-Accept' }
+
+      it_behaves_like 'it saves the right logging information'
+    end
+
     context 'Access-Reject' do
       let(:authentication_result) { 'Access-Reject' }
 
-      it 'does not record a session' do
-        expect(Session.count).to eq(0)
-      end
-
-      it 'does not record last_login for the user' do
-        post_auth_request
-        expect(user.last_login).to be_nil
-      end
-
-      it 'returns a 204 OK' do
-        expect(last_response.status).to eq(204)
-      end
+      it_behaves_like 'it saves the right logging information'
     end
 
     context 'Invalid authentication result' do

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -24,11 +24,6 @@ describe App do
           expect(Session.count).to eq(1)
         end
 
-        it 'updates the user last login' do
-          post_auth_request
-          expect(user.last_login).to_not be_nil
-        end
-
         context 'given a lowercase username' do
           let(:username) { 'abcdef' }
 
@@ -131,12 +126,23 @@ describe App do
       let(:authentication_result) { 'Access-Accept' }
 
       it_behaves_like 'it saves the right logging information'
+
+      it 'updates the user last login' do
+        post_auth_request
+        expect(user.last_login).to_not be_nil
+      end
+
     end
 
     context 'Access-Reject' do
       let(:authentication_result) { 'Access-Reject' }
 
       it_behaves_like 'it saves the right logging information'
+
+      it 'updates the user last login' do
+        post_auth_request
+        expect(user.last_login).to be_nil
+      end
     end
 
     context 'Invalid authentication result' do

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -131,7 +131,6 @@ describe App do
         post_auth_request
         expect(user.last_login).to_not be_nil
       end
-
     end
 
     context 'Access-Reject' do


### PR DESCRIPTION
This is so we can provide meaningful information through admin to GovWifi organisations