### PR TITLE
Save success status on sessions table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,4 +146,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -21,7 +21,8 @@ module Logging
         mac: formatted_mac(@params.fetch(:mac)),
         ap: ap(@params.fetch(:called_station_id)),
         siteIP: @params.fetch(:site_ip_address),
-        building_identifier: building_identifier(@params.fetch(:called_station_id))
+        building_identifier: building_identifier(@params.fetch(:called_station_id)),
+        success: access_accept?
       )
     end
 

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -13,6 +13,7 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
             (ip_locations.ip = sessions.siteIP)
         WHERE
           date(sessions.start) = '#{date - 1}'
+          AND sessions.success = 1
         GROUP BY
             date(start)").first
     end

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE `sessions` (
   `mac` char(17) DEFAULT NULL,
   `ap` char(17) DEFAULT NULL,
   `building_identifier` varchar(20) DEFAULT NULL,
+  `success` BOOLEAN DEFAULT 1,
   PRIMARY KEY (`id`),
   KEY `siteIP` (`siteIP`,`username`),
   KEY `sessions_username` (`username`),
@@ -130,4 +131,3 @@ CREATE TABLE `siteip` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2018-04-18 11:33:13sess
-

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -1,3 +1,4 @@
+require "pry"
 describe App do
   before do
     DB[:sessions].truncate
@@ -131,6 +132,11 @@ describe App do
         post_auth_request
         expect(user.last_login).to_not be_nil
       end
+
+      it 'sets success to true' do
+        post_auth_request
+        expect(Session.last.success).to eq(true)
+      end
     end
 
     context 'Access-Reject' do
@@ -141,6 +147,11 @@ describe App do
       it 'updates the user last login' do
         post_auth_request
         expect(user.last_login).to be_nil
+      end
+
+      it 'sets success to false' do
+        post_auth_request
+        expect(Session.last.success).to eq(false)
       end
     end
 

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -144,7 +144,7 @@ describe App do
 
       it_behaves_like 'it saves the right logging information'
 
-      it 'updates the user last login' do
+      it 'does not update the user last login' do
         post_auth_request
         expect(user.last_login).to be_nil
       end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -1,4 +1,3 @@
-require "pry"
 describe App do
   before do
     DB[:sessions].truncate

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -22,12 +22,20 @@ describe PerformancePlatform::Gateway::AccountUsage do
   end
 
   describe 'one user' do
-    context 'with one session' do
+    context 'with one successful session and one rejected session' do
       before do
         sessions.insert(
           siteIP: ip_A1,
           username: 'alice',
-          start: Date.today - 1
+          start: Date.today - 1,
+          success: 1
+        )
+
+        sessions.insert(
+          siteIP: ip_A1,
+          username: 'alice',
+          start: Date.today - 1,
+          success: 0
         )
       end
 
@@ -187,6 +195,35 @@ describe PerformancePlatform::Gateway::AccountUsage do
   end
 
   context 'zero sessions' do
+    it 'generates the correct (empty) stats' do
+      expect(subject.fetch_stats).to eq(
+        total: 0,
+        transactions: 0,
+        roaming: 0,
+        one_time: 0,
+        metric_name: 'account-usage',
+        period: 'week',
+      )
+    end
+  end
+
+  context 'with only access reject sessions' do
+    before do
+      sessions.insert(
+        siteIP: ip_A1,
+        username: 'alice',
+        start: Date.today - 1,
+        success: 0
+      )
+
+      sessions.insert(
+        siteIP: ip_A1,
+        username: 'bob',
+        start: Date.today - 1,
+        success: 0
+      )
+    end
+
     it 'generates the correct (empty) stats' do
       expect(subject.fetch_stats).to eq(
         total: 0,


### PR DESCRIPTION
- Add `success` column to `sessions` table
- Set `success` boolean based on access accept/reject
- Ensure that only successful sessions are sent to performance platform