### PR TITLE
Record only successful sessions

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -3,11 +3,14 @@ module Logging
     def execute(params:)
       @params = params
 
-      return false unless access_accept? || access_reject?
       return true if username == 'HEALTH'
 
-      update_user_last_login unless access_reject?
-      create_session
+      return false unless access_accept? || access_reject?
+
+      if access_accept?
+        update_user_last_login
+        create_session
+      end
     end
 
   private
@@ -21,8 +24,7 @@ module Logging
         mac: formatted_mac(@params.fetch(:mac)),
         ap: ap(@params.fetch(:called_station_id)),
         siteIP: @params.fetch(:site_ip_address),
-        building_identifier: building_identifier(@params.fetch(:called_station_id)),
-        success: access_accept?
+        building_identifier: building_identifier(@params.fetch(:called_station_id))
       )
     end
 

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -13,9 +13,8 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
             (ip_locations.ip = sessions.siteIP)
         WHERE
           date(sessions.start) = '#{date - 1}'
-          AND sessions.success = 1
         GROUP BY
-            date(start)").first
+          date(start)").first
     end
 
     def unique_users_stats(period:, date:)

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -39,7 +39,6 @@ CREATE TABLE `sessions` (
   `mac` char(17) DEFAULT NULL,
   `ap` char(17) DEFAULT NULL,
   `building_identifier` varchar(20) DEFAULT NULL,
-  `success` BOOLEAN DEFAULT 1,
   PRIMARY KEY (`id`),
   KEY `siteIP` (`siteIP`,`username`),
   KEY `sessions_username` (`username`),

--- a/spec/lib/performance_platform/gateway/account_usage_spec.rb
+++ b/spec/lib/performance_platform/gateway/account_usage_spec.rb
@@ -22,20 +22,12 @@ describe PerformancePlatform::Gateway::AccountUsage do
   end
 
   describe 'one user' do
-    context 'with one successful session and one rejected session' do
+    context 'with one successful session' do
       before do
         sessions.insert(
           siteIP: ip_A1,
           username: 'alice',
-          start: Date.today - 1,
-          success: 1
-        )
-
-        sessions.insert(
-          siteIP: ip_A1,
-          username: 'alice',
-          start: Date.today - 1,
-          success: 0
+          start: Date.today - 1
         )
       end
 
@@ -195,35 +187,6 @@ describe PerformancePlatform::Gateway::AccountUsage do
   end
 
   context 'zero sessions' do
-    it 'generates the correct (empty) stats' do
-      expect(subject.fetch_stats).to eq(
-        total: 0,
-        transactions: 0,
-        roaming: 0,
-        one_time: 0,
-        metric_name: 'account-usage',
-        period: 'week',
-      )
-    end
-  end
-
-  context 'with only access reject sessions' do
-    before do
-      sessions.insert(
-        siteIP: ip_A1,
-        username: 'alice',
-        start: Date.today - 1,
-        success: 0
-      )
-
-      sessions.insert(
-        siteIP: ip_A1,
-        username: 'bob',
-        start: Date.today - 1,
-        success: 0
-      )
-    end
-
     it 'generates the correct (empty) stats' do
       expect(subject.fetch_stats).to eq(
         total: 0,


### PR DESCRIPTION
We want to expose logs to the admin platform through an API (see #58), but it's difficult to add a `success` column to the existing giant `sessions` table. 

My proposal:
- Write only successes to existing `sessions` table
- Add new table - `recent_sessions` (this'll be in the `build` repo)
- Write successes AND failures to `recent_sessions`
- Introduce endpoint exposing 100 newest recent_sessions for a given username (modify #58)
- _(We need to decide what the steps after this are, but this leaves our options open)_

This PR is step 1 - writing only successes.

(This unpicks some of the work from #59 and #60, but doesn't straight revert them because there were some useful refactors included within)