### PR TITLE
Fix Dockerfile Ruby to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.5.1-alpine
 ARG BUNDLE_INSTALL_CMD
 
 ENV S3_PUBLISHED_LOCATIONS_IPS_BUCKET 'stub-bucket'


### PR DESCRIPTION
Avoids Ruby mismatch errors with Gemfile etc, and errors when running `make build`.