### PR TITLE
Don't output stacktraces to the logs for staging and production

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,6 +11,10 @@ class App < Sinatra::Base
     enable :json
   end
 
+  configure :production, :staging do
+    set :dump_errors, false
+  end
+
   get '/healthcheck' do
     'Healthy'
   end


### PR DESCRIPTION
When we were reviewing the logs setup for the apps, we noticed that full blown stack traces are making lots of noise in there, when we already have Sentry setup for these sorts of things.