### PR TITLE
[WIP] : record logs when username is long (as a cert name)

### DIFF
--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -35,7 +35,7 @@ CREATE TABLE `sessions` (
   `start` timestamp NULL DEFAULT NULL,
   `stop` timestamp NULL DEFAULT NULL,
   `siteIP` char(15) DEFAULT NULL,
-  `username` char(6) DEFAULT NULL,
+  `username` char(64) DEFAULT NULL,
   `mac` char(17) DEFAULT NULL,
   `ap` char(17) DEFAULT NULL,
   `building_identifier` varchar(20) DEFAULT NULL,

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -9,108 +9,103 @@ describe App do
     let(:mac) { 'DA-59-19-8B-39-2D' }
     let(:called_station_id) { '01-39-38-25-2A-80' }
     let(:site_ip_address) { '93.11.238.187' }
-    let(:post_auth_request) { get "/logging/post-auth/user/#{username}/mac/#{mac}/ap/#{called_station_id}/site/#{site_ip_address}/result/#{authentication_result}" }
+    let(:post_auth_request) { get "/logging/post-auth/user/#{URI.encode(username)}/mac/#{mac}/ap/#{called_station_id}/site/#{site_ip_address}/result/#{authentication_result}" }
     let(:user) { User.find(username: username) }
     let(:session) { Session.first }
 
-    before do
-      User.create(username: username)
-      post_auth_request
-    end
-
     shared_examples 'it saves the right logging information' do
-      context 'GovWifi user' do
-        it 'creates a single session record' do
-          expect(Session.count).to eq(1)
+      before { post_auth_request }
+
+      it 'creates a single session record' do
+        expect(Session.count).to eq(1)
+      end
+
+      context 'given a lowercase username' do
+        let(:username) { 'abcdef' }
+
+        it 'ensures that the username is saved in uppercase' do
+          expect(session.username).to eq('ABCDEF')
         end
+      end
 
-        context 'given a lowercase username' do
-          let(:username) { 'abcdef' }
+      it 'records the start time of the session' do
+        expect(session.start).to_not be_nil
+      end
 
-          it 'ensures that the username is saved in uppercase' do
-            expect(session.username).to eq('ABCDEF')
-          end
-        end
+      it 'records the session details' do
+        expect(session.username).to eq(username)
+        expect(session.mac).to eq(mac)
+        expect(session.ap).to eq(called_station_id)
+        expect(session.siteIP).to eq(site_ip_address)
+      end
 
-        it 'records the start time of the session' do
-          expect(session.start).to_not be_nil
-        end
+      context 'Given the "Called Station ID" is an MAC address' do
+        let(:called_station_id) { '01-39-38-25-2A-80' }
 
-        it 'records the session details' do
-          expect(session.username).to eq(username)
-          expect(session.mac).to eq(mac)
+        it 'saves it as the access point' do
           expect(session.ap).to eq(called_station_id)
-          expect(session.siteIP).to eq(site_ip_address)
         end
 
-        context 'Given the "Called Station ID" is an MAC address' do
-          let(:called_station_id) { '01-39-38-25-2A-80' }
+        it 'does not save it as the building identifier' do
+          expect(session.building_identifier).to be_nil
+        end
 
-          it 'saves it as the access point' do
-            expect(session.ap).to eq(called_station_id)
-          end
+        context 'Given the Called Station ID needs to be formatted' do
+          let(:called_station_id) { 'aa-bb-cc-25-2a-80' }
 
-          it 'does not save it as the building identifier' do
-            expect(session.building_identifier).to be_nil
-          end
-
-          context 'Given the Called Station ID needs to be formatted' do
-            let(:called_station_id) { 'aa-bb-cc-25-2a-80' }
-
-            it 'formats the Called Station ID' do
-              expect(session.ap).to eq('AA-BB-CC-25-2A-80')
-            end
-          end
-
-          context 'Given a Called Station ID has extra trailing characters' do
-            let(:called_station_id) { 'C4-13-E2-22-DC-55%3ASTAGING-GovWifi' }
-
-            it 'Formats it and considers it a valid access point' do
-              expect(session.ap).to eq('C4-13-E2-22-DC-55')
-              expect(session.building_identifier).to be_nil
-            end
+          it 'formats the Called Station ID' do
+            expect(session.ap).to eq('AA-BB-CC-25-2A-80')
           end
         end
 
-        context 'Given the "Called Station ID" is a building identifier' do
-          let(:called_station_id) { 'Building-Identifier' }
+        context 'Given a Called Station ID has extra trailing characters' do
+          let(:called_station_id) { 'C4-13-E2-22-DC-55%3ASTAGING-GovWifi' }
 
-          it 'saves it as a building identifier' do
-            expect(session.building_identifier).to eq(called_station_id)
-          end
-
-          it 'does not save it as an access point' do
-            expect(session.ap).to eq('')
-          end
-        end
-
-        context 'Given a blank "Called Station ID"' do
-          let(:called_station_id) { '' }
-
-          it 'does not save the ap' do
-            expect(session.ap).to eq('')
-          end
-
-          it 'does not save the building_identifier' do
+          it 'Formats it and considers it a valid access point' do
+            expect(session.ap).to eq('C4-13-E2-22-DC-55')
             expect(session.building_identifier).to be_nil
           end
         end
+      end
 
-        context 'HEALTH user' do
-          let(:username) { 'HEALTH' }
+      context 'Given the "Called Station ID" is a building identifier' do
+        let(:called_station_id) { 'Building-Identifier' }
 
-          it 'does not update the last login' do
-            post_auth_request
-            expect(user.last_login).to be_nil
-          end
+        it 'saves it as a building identifier' do
+          expect(session.building_identifier).to eq(called_station_id)
+        end
 
-          it 'returns a 204 status code' do
-            expect(last_response.status).to eq(204)
-          end
+        it 'does not save it as an access point' do
+          expect(session.ap).to eq('')
+        end
+      end
 
-          it 'does not create a session record' do
-            expect(Session.count).to eq(0)
-          end
+      context 'Given a blank "Called Station ID"' do
+        let(:called_station_id) { '' }
+
+        it 'does not save the ap' do
+          expect(session.ap).to eq('')
+        end
+
+        it 'does not save the building_identifier' do
+          expect(session.building_identifier).to be_nil
+        end
+      end
+
+      context 'HEALTH user' do
+        let(:username) { 'HEALTH' }
+
+        it 'does not update the last login' do
+          post_auth_request
+          expect(user.last_login).to be_nil
+        end
+
+        it 'returns a 204 status code' do
+          expect(last_response.status).to eq(204)
+        end
+
+        it 'does not create a session record' do
+          expect(Session.count).to eq(0)
         end
       end
 
@@ -122,39 +117,59 @@ describe App do
       end
     end
 
-    context 'Access-Accept' do
-      let(:authentication_result) { 'Access-Accept' }
+    context 'with a pre-existing user' do
+      before { User.create(username: username) }
 
-      it_behaves_like 'it saves the right logging information'
+      context 'Access-Accept' do
+        let(:authentication_result) { 'Access-Accept' }
 
-      it 'updates the user last login' do
-        post_auth_request
-        expect(user.last_login).to_not be_nil
+        it_behaves_like 'it saves the right logging information'
+
+        it 'updates the user last login' do
+          post_auth_request
+          expect(user.last_login).to_not be_nil
+        end
+
+        it 'sets success to true' do
+          post_auth_request
+          expect(Session.last.success).to eq(true)
+        end
       end
 
-      it 'sets success to true' do
-        post_auth_request
-        expect(Session.last.success).to eq(true)
+      context 'Access-Reject' do
+        let(:authentication_result) { 'Access-Reject' }
+
+        it_behaves_like 'it saves the right logging information'
+
+        it 'does not update the user last login' do
+          post_auth_request
+          expect(user.last_login).to be_nil
+        end
+
+        it 'sets success to false' do
+          post_auth_request
+          expect(Session.last.success).to eq(false)
+        end
       end
     end
 
-    context 'Access-Reject' do
-      let(:authentication_result) { 'Access-Reject' }
+    context 'without a user record (certs)' do
+      before { post_auth_request }
 
-      it_behaves_like 'it saves the right logging information'
+      let(:authentication_result) { 'Access-Accept' }
 
-      it 'does not update the user last login' do
-        post_auth_request
-        expect(user.last_login).to be_nil
-      end
+      context 'given a max length certificate common name' do
+        let(:username) { 'A Max Length Certificate Common Name Really 64 Characters Long' }
 
-      it 'sets success to false' do
-        post_auth_request
-        expect(Session.last.success).to eq(false)
+        it 'saves the username' do
+          expect(session.username).to eq(username.upcase)
+        end
       end
     end
 
     context 'Invalid authentication result' do
+      before { post_auth_request }
+
       context 'unknown string authentication result' do
         let(:authentication_result) { 'unknown' }
 


### PR DESCRIPTION
This can't be merged because it requires changes to the database specifically the username field in sessions.
Tests work because they rely on the required changes made to the `schema.rb` file.