### PR TITLE
Run Session Deletion as an ECS Scheduled Task

### DIFF
--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -1,0 +1,5 @@
+class Gdpr::Gateway::Session
+  def delete_sessions
+    DB.run('DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 90 DAY)')
+  end
+end

--- a/lib/gdpr/use_case/session_deletion.rb
+++ b/lib/gdpr/use_case/session_deletion.rb
@@ -1,0 +1,13 @@
+class Gdpr::UseCase::SessionDeletion
+  def initialize(session_gateway:)
+    @session_gateway = session_gateway
+  end
+
+  def execute
+    session_gateway.delete_sessions
+  end
+
+private
+
+  attr_reader :session_gateway
+end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -31,4 +31,9 @@ module PerformancePlatform
   module Presenter; end
 end
 
+module Gdpr
+  module Gateway; end
+  module UseCase; end
+end
+
 require_all 'lib'

--- a/spec/features/daily_session_deletion_spec.rb
+++ b/spec/features/daily_session_deletion_spec.rb
@@ -1,0 +1,18 @@
+describe 'daily session deletion' do
+  subject { Gdpr::UseCase::SessionDeletion.new(session_gateway: Gdpr::Gateway::Session.new) }
+  let(:session) { DB[:sessions] }
+
+  context 'Given sessions older than 3 months' do
+    before do
+      session.delete
+      session.insert(start: Date.today, username: 'bob')
+      session.insert(start: Date.today, username: 'sally')
+      session.insert(start: Date.today - 120, username: 'george')
+    end
+
+    it 'deletes the session' do
+      subject.execute
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
+    end
+  end
+end

--- a/spec/lib/gdpr/gateway/session_spec.rb
+++ b/spec/lib/gdpr/gateway/session_spec.rb
@@ -1,0 +1,41 @@
+describe Gdpr::Gateway::Session do
+  let(:session) { DB[:sessions] }
+  before { session.delete }
+
+  context 'Given some sessions are older than 3 months' do
+    before do
+      session.insert(start: Date.today, username: 'bob')
+      session.insert(start: Date.today, username: 'sally')
+      session.insert(start: Date.today - 120, username: 'george')
+    end
+
+    it 'deletes the old sessions' do
+      subject.delete_sessions
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
+    end
+  end
+
+  context 'Given all sessions are recent' do
+    before do
+      session.insert(start: Date.today, username: 'sally')
+      session.insert(start: Date.today, username: 'george')
+    end
+
+    it 'does not delete the sessions' do
+      subject.delete_sessions
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(sally george))
+    end
+  end
+
+  context 'Given all sessions are old' do
+    before do
+      session.insert(start: Date.today - 120, username: 'Adam')
+      session.insert(start: Date.today - 120, username: 'Betty')
+    end
+
+    it 'deletes the sessions' do
+      subject.delete_sessions
+      expect(session.all.map { |s| s.fetch(:username) }).to be_empty
+    end
+  end
+end

--- a/spec/lib/gdpr/use_case/session_deletion_spec.rb
+++ b/spec/lib/gdpr/use_case/session_deletion_spec.rb
@@ -1,0 +1,16 @@
+describe Gdpr::UseCase::SessionDeletion do
+  subject do
+    described_class.new(
+      session_gateway: session_gateway
+    )
+  end
+
+  let(:session_gateway) { double(delete_sessions: nil) }
+
+  context 'Given a session gateway' do
+    it 'calls delete_sessions on the gateway' do
+      subject.execute
+      expect(session_gateway).to have_received(:delete_sessions)
+    end
+  end
+end

--- a/tasks/session_deletion.rb
+++ b/tasks/session_deletion.rb
@@ -1,0 +1,9 @@
+require 'logger'
+logger = Logger.new(STDOUT)
+
+task :daily_session_deletion do
+  session_gateway = Gdpr::Gateway::Session.new
+  Gdpr::UseCase::SessionDeletion.new(session_gateway: session_gateway).execute
+
+  logger.info('Daily Session Deletion Ran')
+end


### PR DESCRIPTION
We are deprecating the Lambda functions to keep us GDPR compliant since
most of our cron tasks run in ECS.  Better to have only one service do
all the crons.

This will run daily and delete sessions older than 3 months.