### PR TITLE
Auto Load Session Deletion Rake Task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
 require './lib/loader'
 
 require './tasks/publish_statistics'
+require './tasks/session_deletion'


### PR DESCRIPTION
Rake doesn't auto discover tasks; you have to manually include it.