### PR TITLE
Setup and configure sensible_logging gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sentry-raven'
 gem 'sequel', '~> 5.14'
 gem 'sinatra'
 gem 'sinatra-contrib'
-gem 'sensible_logging', '~> 0.2.0'
+gem 'sensible_logging', '~> 0.3.0'
 
 group :test do
   gem 'govuk-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sentry-raven'
 gem 'sequel', '~> 5.14'
 gem 'sinatra'
 gem 'sinatra-contrib'
+gem 'sensible_logging', '~> 0.2.0'
 
 group :test do
   gem 'govuk-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ gem 'mysql2'
 gem 'puma'
 gem 'rake', '~> 12.3'
 gem 'require_all'
+gem 'sensible_logging', '~> 0.3.0'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.14'
 gem 'sinatra'
 gem 'sinatra-contrib'
-gem 'sensible_logging', '~> 0.3.0'
 
 group :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    sensible_logging (0.2.0)
+      activesupport (~> 5.2)
+      rack (~> 2.0)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     sequel (5.14.0)
@@ -142,6 +145,7 @@ DEPENDENCIES
   rake (~> 12.3)
   require_all
   rspec
+  sensible_logging (~> 0.2.0)
   sentry-raven
   sequel (~> 5.14)
   simplecov
@@ -154,4 +158,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
-    sensible_logging (0.2.0)
+    sensible_logging (0.3.0)
       activesupport (~> 5.2)
       rack (~> 2.0)
     sentry-raven (2.7.4)
@@ -145,7 +145,7 @@ DEPENDENCIES
   rake (~> 12.3)
   require_all
   rspec
-  sensible_logging (~> 0.2.0)
+  sensible_logging (~> 0.3.0)
   sentry-raven
   sequel (~> 5.14)
   simplecov

--- a/app.rb
+++ b/app.rb
@@ -7,7 +7,7 @@ require 'sinatra/json'
 require './lib/loader'
 
 class App < Sinatra::Base
-  register SensibleLogging
+  register Sinatra::SensibleLogging
 
   configure do
     enable :json

--- a/app.rb
+++ b/app.rb
@@ -7,10 +7,9 @@ require './lib/loader'
 
 class App < Sinatra::Base
   configure do
-    enable :logging
     enable :json
 
-    set :logging, Logger::DEBUG
+    set :log_level, Logger::DEBUG
   end
 
   configure :production, :staging do
@@ -18,7 +17,7 @@ class App < Sinatra::Base
   end
 
   configure :production do
-    set :logging, Logger::INFO
+    set :log_level, Logger::INFO
   end
 
   get '/healthcheck' do

--- a/app.rb
+++ b/app.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 require 'sequel'
+require 'sensible_logging'
 require 'sinatra/base'
 require 'sinatra/json'
 require './lib/loader'
 
 class App < Sinatra::Base
+  register SensibleLogging
+
   configure do
     enable :json
+
+    sensible_logging(
+      logger: Logger.new(STDOUT)
+    )
 
     set :log_level, Logger::DEBUG
   end

--- a/app.rb
+++ b/app.rb
@@ -9,13 +9,12 @@ require './lib/loader'
 class App < Sinatra::Base
   register Sinatra::SensibleLogging
 
+  sensible_logging(
+    logger: Logger.new(STDOUT)
+  )
+
   configure do
     enable :json
-
-    sensible_logging(
-      logger: Logger.new(STDOUT)
-    )
-
     set :log_level, Logger::DEBUG
   end
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 #\ --quiet
-# The above is needed to prevent rack from logging
+# The above is needed to prevent rack from request logging
 
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,11 @@
+#\ --quiet
+
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
+require 'sensible_logging'
 require './app'
-run App
+
+run sensible_logging(
+  app: App,
+  logger: Logger.new(STDOUT)
+)

--- a/config.ru
+++ b/config.ru
@@ -1,11 +1,7 @@
 #\ --quiet
+# The above is needed to prevent rack from logging
 
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
-require 'sensible_logging'
 require './app'
-
-run sensible_logging(
-  app: App,
-  logger: Logger.new(STDOUT)
-)
+run App


### PR DESCRIPTION
Sets up [sensible_logging](https://github.com/madetech/sensible_logging) gem which provides:

* Tagged logging
* Request ID (for tagged logging, and to include in Sentry exceptions in future)
* Minimal request log format

Example output from request logging:

```
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] method=GET path=/healthcheck status=200 duration=0.0207032 params={"test"=>"one", "two"=>"three"}
```

If you reference the built in Sinatra `logger` helper within the app/routes, then you'll see output like:

```
get 'healthcheck' do
  logger.debug('testing')
  'Healthcheck'
end
```

```
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] testing
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] method=GET path=/healthcheck status=200 duration=0.0207032 params={"test"=>"one", "two"=>"three"}
```