### PR TITLE
Keep less session data in the database

### DIFF
--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -1,5 +1,5 @@
 class Gdpr::Gateway::Session
   def delete_sessions
-    DB.run('DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 90 DAY)')
+    DB.run('DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY)')
   end
 end

--- a/spec/lib/gdpr/gateway/session_spec.rb
+++ b/spec/lib/gdpr/gateway/session_spec.rb
@@ -2,11 +2,11 @@ describe Gdpr::Gateway::Session do
   let(:session) { DB[:sessions] }
   before { session.delete }
 
-  context 'Given some sessions are older than 3 months' do
+  context 'Given some sessions are older than 32 days' do
     before do
       session.insert(start: Date.today, username: 'bob')
       session.insert(start: Date.today, username: 'sally')
-      session.insert(start: Date.today - 120, username: 'george')
+      session.insert(start: Date.today - 33, username: 'george')
     end
 
     it 'deletes the old sessions' do
@@ -29,8 +29,8 @@ describe Gdpr::Gateway::Session do
 
   context 'Given all sessions are old' do
     before do
-      session.insert(start: Date.today - 120, username: 'Adam')
-      session.insert(start: Date.today - 120, username: 'Betty')
+      session.insert(start: Date.today - 33, username: 'Adam')
+      session.insert(start: Date.today - 33, username: 'Betty')
     end
 
     it 'deletes the sessions' do


### PR DESCRIPTION
The maximum amount of session data we need to do reporting is 1 month.
Originally we kept more than this to facilitate with criminal investigations,
this can still be done using Cloudwatch instead of the database.

This should reduce the size of the sessions table by 2 thirds, making it
less difficult to manage and enabling us to switch to a less expensive
RDS image down the line.