### PR TITLE
Never return 404

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,12 +31,13 @@ class App < Sinatra::Base
   end
 
   get '/logging/post-auth/user/?:username?/cert-name/?:cert_name?/mac/?:mac?/ap/?:called_station_id?/site/?:site_ip_address?/result/:authentication_result' do
-    post_auth_success = Logging::PostAuth.new.execute(params: params)
+    Logging::PostAuth.new.execute(params: params)
 
-    if post_auth_success
-      status 204
-    else
-      status 404
-    end
+    status 204
+  end
+
+  get '/*' do
+    logger.info("Unhandled logging request: #{request}")
+    status 204
   end
 end

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -3,7 +3,6 @@ module Logging
     def execute(params:)
       @params = params
 
-      return false unless access_accept? || access_reject?
       return handle_username_request unless @params[:cert_name]
 
       create_cert_session

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -164,23 +164,6 @@ describe App do
     end
 
     context 'Invalid authentication result' do
-      context 'unknown string authentication result' do
-        let(:authentication_result) { 'unknown' }
-
-        it 'returns a 404 for anything other than Access-Accept or Access-Reject' do
-          expect(Session.count).to eq(0)
-          expect(last_response.status).to eq(404)
-        end
-      end
-
-      context 'Blank authentication result' do
-        let(:authentication_result) { '' }
-
-        it 'returns a 404 for anything other than Access-Accept or Access-Reject' do
-          expect(last_response.status).to eq(404)
-        end
-      end
-
       context 'Given parameters are missing from the GET request' do
         let(:authentication_result) { 'Access-Accept' }
         let(:username) { '' }
@@ -193,6 +176,13 @@ describe App do
 
         it 'creates a session record' do
           expect(Session.all.count).to eq(1)
+        end
+      end
+
+      context 'Non existent route' do
+        let(:post_auth_request) { get '/some-path/that/does/not/exist' }
+        it 'returns a 204 regardless of defined routes' do
+          expect(last_response.status).to eq(204)
         end
       end
     end


### PR DESCRIPTION
Given Logging has been removed from the "critical path", we never want
it to influence the result of the radius request based on a logging
operation.

If the logging API returns a 404, it will implicitly change an
Access-Accept to an Access-Reject.  We never want this to happen.

Always return a 204, indicating to the radius servers that everything
has gone well.