### PR TITLE
Don't populate last_login for users

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -35,14 +35,6 @@ module Logging
       }
     end
 
-    def update_user_last_login
-      user = User.find(username: username)
-      return unless user
-
-      user.last_login = Time.now
-      user.save
-    end
-
     def access_reject?
       @params.fetch(:authentication_result) == 'Access-Reject'
     end
@@ -77,7 +69,6 @@ module Logging
     def handle_username_request
       return true if username == 'HEALTH'
 
-      update_user_last_login unless access_reject?
       create_user_session
     end
   end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -108,11 +108,6 @@ describe App do
         context 'HEALTH user' do
           let(:username) { 'HEALTH' }
 
-          it 'does not update the last login' do
-            post_auth_request
-            expect(user.last_login).to be_nil
-          end
-
           it 'returns a 204 status code' do
             expect(last_response.status).to eq(204)
           end
@@ -136,11 +131,6 @@ describe App do
 
       it_behaves_like 'it saves the right logging information'
 
-      it 'updates the user last login' do
-        post_auth_request
-        expect(user.last_login).to_not be_nil
-      end
-
       it 'sets success to true' do
         post_auth_request
         expect(Session.last.success).to eq(true)
@@ -151,11 +141,6 @@ describe App do
       let(:authentication_result) { 'Access-Reject' }
 
       it_behaves_like 'it saves the right logging information'
-
-      it 'does not update the user last login' do
-        post_auth_request
-        expect(user.last_login).to be_nil
-      end
 
       it 'sets success to false' do
         post_auth_request


### PR DESCRIPTION
This will now be done by the authorisation API when a user attempts a
login.

By making this change, this API won't need access to the users
table at all.