### PR TITLE
Add a POST endpoint for the post-auth request

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -36,6 +36,12 @@ class App < Sinatra::Base
     status 204
   end
 
+  post '/logging/post-auth' do
+    Logging::PostAuth.new.execute(params: JSON.parse(request.body.read))
+
+    status 204
+  end
+
   get '/*' do
     logger.info("Unhandled logging request: #{request.path}")
     status 204

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -3,7 +3,7 @@ module Logging
     def execute(params:)
       @params = params
 
-      return handle_username_request unless @params[:cert_name]
+      return handle_username_request unless @params['cert_name'].present?
 
       create_cert_session
     end
@@ -19,7 +19,7 @@ module Logging
     def create_cert_session
       Session.create(
         session_params.merge(
-          cert_name: @params.fetch(:cert_name)
+          cert_name: @params.fetch('cert_name')
         )
       )
     end
@@ -27,10 +27,10 @@ module Logging
     def session_params
       {
         start: Time.now,
-        mac: formatted_mac(@params.fetch(:mac)),
-        ap: ap(@params.fetch(:called_station_id)),
-        siteIP: @params.fetch(:site_ip_address),
-        building_identifier: building_identifier(@params.fetch(:called_station_id)),
+        mac: formatted_mac(@params.fetch('mac')),
+        ap: ap(@params.fetch('called_station_id')),
+        siteIP: @params.fetch('site_ip_address'),
+        building_identifier: building_identifier(@params.fetch('called_station_id')),
         success: access_accept?
       }
     end
@@ -44,15 +44,15 @@ module Logging
     end
 
     def access_reject?
-      @params.fetch(:authentication_result) == 'Access-Reject'
+      @params.fetch('authentication_result') == 'Access-Reject'
     end
 
     def access_accept?
-      @params.fetch(:authentication_result) == 'Access-Accept'
+      @params.fetch('authentication_result') == 'Access-Accept'
     end
 
     def username
-      @params.fetch(:username)
+      @params.fetch('username')
     end
 
     def formatted_mac(unformatted_mac)

--- a/spec/features/get_method_certs_logging_spec.rb
+++ b/spec/features/get_method_certs_logging_spec.rb
@@ -4,7 +4,7 @@ describe App do
     DB[:userdetails].truncate
   end
 
-  describe 'certificate post-auth logging' do
+  describe 'certificate post-auth logging with GET' do
     shared_examples 'logging' do
       let(:post_auth_request) { get "/logging/post-auth/user/#{username}/cert-name/#{encoded_cert_name}/mac//ap//site//result/#{authentication_result}" }
       let(:encoded_cert_name) { 'Example%20Certificate%20Common%20Name' }

--- a/spec/features/get_method_post_auth_spec.rb
+++ b/spec/features/get_method_post_auth_spec.rb
@@ -1,0 +1,190 @@
+describe App do
+  before do
+    DB[:sessions].truncate
+    DB[:userdetails].truncate
+  end
+
+  describe 'GET post-auth' do
+    let(:username) { 'VYKZDX' }
+    let(:mac) { 'DA-59-19-8B-39-2D' }
+    let(:called_station_id) { '01-39-38-25-2A-80' }
+    let(:site_ip_address) { '93.11.238.187' }
+    let(:cert_name) { '' }
+    let(:post_auth_request) { get "/logging/post-auth/user/#{username}/cert-name/#{cert_name}/mac/#{mac}/ap/#{called_station_id}/site/#{site_ip_address}/result/#{authentication_result}" }
+    let(:user) { User.find(username: username) }
+    let(:session) { Session.first }
+
+    before do
+      User.create(username: username)
+      post_auth_request
+    end
+
+    shared_examples 'it saves the right logging information' do
+      context 'GovWifi user' do
+        it 'creates a single session record' do
+          expect(Session.count).to eq(1)
+        end
+
+        context 'given a certificate authentication' do
+          let(:cert_name) { 'some_cert_name' }
+
+          it 'records the cert name' do
+            expect(session.cert_name).to eq(cert_name)
+          end
+        end
+
+        context 'given a lowercase username' do
+          let(:username) { 'abcdef' }
+
+          it 'ensures that the username is saved in uppercase' do
+            expect(session.username).to eq('ABCDEF')
+          end
+        end
+
+        it 'records the start time of the session' do
+          expect(session.start).to_not be_nil
+        end
+
+        it 'records the session details' do
+          expect(session.username).to eq(username)
+          expect(session.mac).to eq(mac)
+          expect(session.ap).to eq(called_station_id)
+          expect(session.siteIP).to eq(site_ip_address)
+        end
+
+        context 'Given the "Called Station ID" is an MAC address' do
+          let(:called_station_id) { '01-39-38-25-2A-80' }
+
+          it 'saves it as the access point' do
+            expect(session.ap).to eq(called_station_id)
+          end
+
+          it 'does not save it as the building identifier' do
+            expect(session.building_identifier).to be_nil
+          end
+
+          context 'Given the Called Station ID needs to be formatted' do
+            let(:called_station_id) { 'aa-bb-cc-25-2a-80' }
+
+            it 'formats the Called Station ID' do
+              expect(session.ap).to eq('AA-BB-CC-25-2A-80')
+            end
+          end
+
+          context 'Given a Called Station ID has extra trailing characters' do
+            let(:called_station_id) { 'C4-13-E2-22-DC-55%3ASTAGING-GovWifi' }
+
+            it 'Formats it and considers it a valid access point' do
+              expect(session.ap).to eq('C4-13-E2-22-DC-55')
+              expect(session.building_identifier).to be_nil
+            end
+          end
+        end
+
+        context 'Given the "Called Station ID" is a building identifier' do
+          let(:called_station_id) { 'Building-Identifier' }
+
+          it 'saves it as a building identifier' do
+            expect(session.building_identifier).to eq(called_station_id)
+          end
+
+          it 'does not save it as an access point' do
+            expect(session.ap).to eq('')
+          end
+        end
+
+        context 'Given a blank "Called Station ID"' do
+          let(:called_station_id) { '' }
+
+          it 'does not save the ap' do
+            expect(session.ap).to eq('')
+          end
+
+          it 'does not save the building_identifier' do
+            expect(session.building_identifier).to be_nil
+          end
+        end
+
+        context 'HEALTH user' do
+          let(:username) { 'HEALTH' }
+
+          it 'does not update the last login' do
+            post_auth_request
+            expect(user.last_login).to be_nil
+          end
+
+          it 'returns a 204 status code' do
+            expect(last_response.status).to eq(204)
+          end
+
+          it 'does not create a session record' do
+            expect(Session.count).to eq(0)
+          end
+        end
+      end
+
+      context 'MAC Formatter' do
+        let(:mac) { '50a67f849cd1' }
+        it 'saves the MAC formatted' do
+          expect(Session.last.mac).to eq('50-A6-7F-84-9C-D1')
+        end
+      end
+    end
+
+    context 'Access-Accept' do
+      let(:authentication_result) { 'Access-Accept' }
+
+      it_behaves_like 'it saves the right logging information'
+
+      it 'updates the user last login' do
+        post_auth_request
+        expect(user.last_login).to_not be_nil
+      end
+
+      it 'sets success to true' do
+        post_auth_request
+        expect(Session.last.success).to eq(true)
+      end
+    end
+
+    context 'Access-Reject' do
+      let(:authentication_result) { 'Access-Reject' }
+
+      it_behaves_like 'it saves the right logging information'
+
+      it 'does not update the user last login' do
+        post_auth_request
+        expect(user.last_login).to be_nil
+      end
+
+      it 'sets success to false' do
+        post_auth_request
+        expect(Session.last.success).to eq(false)
+      end
+    end
+
+    context 'Invalid authentication result' do
+      context 'Given parameters are missing from the GET request' do
+        let(:authentication_result) { 'Access-Accept' }
+        let(:username) { '' }
+        let(:called_station_id) { '' }
+        let(:site_ip_address) { '' }
+
+        it 'returns a 204 status code' do
+          expect(last_response.status).to eq(204)
+        end
+
+        it 'creates a session record' do
+          expect(Session.all.count).to eq(1)
+        end
+      end
+
+      context 'Non existent route' do
+        let(:post_auth_request) { get '/some-path/that/does/not/exist' }
+        it 'returns a 204 regardless of defined routes' do
+          expect(last_response.status).to eq(204)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/post_method_certs_logging_spec.rb
+++ b/spec/features/post_method_certs_logging_spec.rb
@@ -1,0 +1,77 @@
+describe App do
+  before do
+    DB[:sessions].truncate
+    DB[:userdetails].truncate
+  end
+
+  describe 'certificate post-auth logging with POST' do
+    shared_examples 'logging' do
+      let(:request_body) {
+        {
+          username: username,
+          cert_name: cert_name,
+          mac: nil,
+          called_station_id: nil,
+          site_ip_address: nil,
+          authentication_result: authentication_result
+        }.to_json
+      }
+      let(:post_auth_request) { post "/logging/post-auth", request_body }
+      let(:cert_name) { 'Example Certificate Common Name' }
+      let(:authentication_result) { 'Access-Accept' }
+
+      before { post_auth_request }
+
+      it 'a session' do
+        expect(Session.count).to eq(1)
+      end
+
+      it 'the certificate common name' do
+        expect(Session.first[:cert_name]).to eq('Example Certificate Common Name')
+      end
+    end
+
+    context 'with a blank username' do
+      let(:username) { '' }
+
+      it_behaves_like 'logging'
+    end
+
+    context 'with a username' do
+      let(:username) { 'fakeusername' }
+
+      it_behaves_like 'logging'
+    end
+  end
+
+  describe 'user/pass post-auth logging (on new endpoint)' do
+    let(:username) { 'ABCDE' }
+    let(:mac) { 'DA-59-19-8B-39-2D' }
+    let(:authentication_result) { 'Access-Accept' }
+
+    let(:request_body) {
+      {
+        username: username,
+        cert_name: nil,
+        mac: mac,
+        called_station_id: nil,
+        site_ip_address: nil,
+        authentication_result: authentication_result
+      }.to_json
+    }
+    let(:post_auth_request) { post "/logging/post-auth", request_body }
+
+    before do
+      User.create(username: username)
+      post_auth_request
+    end
+
+    it 'writes a session' do
+      expect(Session.count).to eq(1)
+    end
+
+    it 'writes the mac address' do
+      expect(Session.first[:mac]).to eq(mac)
+    end
+  end
+end

--- a/spec/features/post_method_post_auth_spec.rb
+++ b/spec/features/post_method_post_auth_spec.rb
@@ -10,7 +10,17 @@ describe App do
     let(:called_station_id) { '01-39-38-25-2A-80' }
     let(:site_ip_address) { '93.11.238.187' }
     let(:cert_name) { '' }
-    let(:post_auth_request) { get "/logging/post-auth/user/#{username}/cert-name/#{cert_name}/mac/#{mac}/ap/#{called_station_id}/site/#{site_ip_address}/result/#{authentication_result}" }
+    let(:request_body) {
+      {
+        username: username,
+        cert_name: cert_name,
+        mac: mac,
+        called_station_id: called_station_id,
+        site_ip_address: site_ip_address,
+        authentication_result: authentication_result
+      }.to_json
+    }
+    let(:post_auth_request) { post "/logging/post-auth", request_body }
     let(:user) { User.find(username: username) }
     let(:session) { Session.first }
 
@@ -101,7 +111,7 @@ describe App do
           end
 
           it 'does not save the building_identifier' do
-            expect(session.building_identifier).to be_nil
+            expect(session.building_identifier).to be_empty
           end
         end
 


### PR DESCRIPTION
Added a `POST` endpoint for the `post-auth` request from RADIUS. I've added this on top of the existing `GET` request so we can have a smooth transition from `GET` to `POST` from the frontends.

The specs have been duplicated, one for `post_method_` and one for `get_method_`.