### PR TITLE
Rewind the request body for logging post requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,7 +10,13 @@ class App < Sinatra::Base
   register Sinatra::SensibleLogging
 
   sensible_logging(
-    logger: Logger.new(STDOUT)
+    logger: Logger.new(STDOUT),
+    log_tags: [->(req) {
+      req.body.rewind
+      [
+        req.body.read
+      ].tap { req.body.rewind }
+    }]
   )
 
   configure do


### PR DESCRIPTION
You can only read a POST request once, and it has to be rewinded if you
want to read it again.  We need to read it twice, once for logging to
CloudWatch and once for storing it in the database.