### PR TITLE
add shebang to wait_for_mysql

### DIFF
--- a/mysql_user/bin/wait_for_mysql
+++ b/mysql_user/bin/wait_for_mysql
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+
 until docker-compose exec -T user_db mysql -huser_db -uroot -proot -e 'SELECT 1' &> /dev/null
 do
   printf "."


### PR DESCRIPTION
this was causing a silent failure, which prevented Make from waiting for the user db