### PR TITLE
use an update instead of a read + update

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -36,11 +36,7 @@ module Logging
     end
 
     def update_user_last_login
-      user = User.find(username: username)
-      return unless user
-
-      user.last_login = Time.now
-      user.save
+      User.where(username: username).update(last_login: Time.now)
     end
 
     def access_reject?

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -21,15 +21,15 @@ describe App do
       }.to_json
     }
     let(:post_auth_request) { post "/logging/post-auth", request_body }
+    let!(:create_user) { User.create(username: username) }
     let(:user) { User.find(username: username) }
     let(:session) { Session.first }
 
     before do
-      User.create(username: username)
       post_auth_request
     end
 
-    shared_examples 'it saves the right logging information' do
+    shared_examples 'it saves the right logging information inner' do |has_user=true|
       context 'GovWifi user' do
         it 'creates a single session record' do
           expect(Session.count).to eq(1)
@@ -121,7 +121,7 @@ describe App do
           it 'does not update the last login' do
             post_auth_request
             expect(user.last_login).to be_nil
-          end
+          end unless !has_user
 
           it 'returns a 204 status code' do
             expect(last_response.status).to eq(204)
@@ -138,6 +138,17 @@ describe App do
         it 'saves the MAC formatted' do
           expect(Session.last.mac).to eq('50-A6-7F-84-9C-D1')
         end
+      end
+    end
+
+    shared_examples 'it saves the right logging information' do
+      context 'With a user in the database' do
+        it_behaves_like 'it saves the right logging information inner'
+      end
+
+      context 'Without a user in the database' do
+        let!(:create_user) { nil }
+        it_behaves_like 'it saves the right logging information inner', has_user=false
       end
     end
 

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -21,11 +21,11 @@ describe App do
       }.to_json
     }
     let(:post_auth_request) { post "/logging/post-auth", request_body }
+    let!(:create_user) { User.create(username: username) }
     let(:user) { User.find(username: username) }
     let(:session) { Session.first }
 
     before do
-      User.create(username: username)
       post_auth_request
     end
 
@@ -155,6 +155,19 @@ describe App do
         post_auth_request
         expect(Session.last.success).to eq(true)
       end
+
+      context 'Without a user in the database' do
+        let!(:create_user) { nil }
+
+        it 'has not updated a non-existent user' do
+          expect(user).to be_nil
+        end
+
+        it 'sets success to true' do
+          expect(Session.last.success).to eq(true)
+        end
+      end
+
     end
 
     context 'Access-Reject' do

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -167,7 +167,6 @@ describe App do
           expect(Session.last.success).to eq(true)
         end
       end
-
     end
 
     context 'Access-Reject' do

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -21,15 +21,15 @@ describe App do
       }.to_json
     }
     let(:post_auth_request) { post "/logging/post-auth", request_body }
-    let!(:create_user) { User.create(username: username) }
     let(:user) { User.find(username: username) }
     let(:session) { Session.first }
 
     before do
+      User.create(username: username)
       post_auth_request
     end
 
-    shared_examples 'it saves the right logging information inner' do |has_user=true|
+    shared_examples 'it saves the right logging information' do
       context 'GovWifi user' do
         it 'creates a single session record' do
           expect(Session.count).to eq(1)
@@ -121,7 +121,7 @@ describe App do
           it 'does not update the last login' do
             post_auth_request
             expect(user.last_login).to be_nil
-          end unless !has_user
+          end
 
           it 'returns a 204 status code' do
             expect(last_response.status).to eq(204)
@@ -138,17 +138,6 @@ describe App do
         it 'saves the MAC formatted' do
           expect(Session.last.mac).to eq('50-A6-7F-84-9C-D1')
         end
-      end
-    end
-
-    shared_examples 'it saves the right logging information' do
-      context 'With a user in the database' do
-        it_behaves_like 'it saves the right logging information inner'
-      end
-
-      context 'Without a user in the database' do
-        let!(:create_user) { nil }
-        it_behaves_like 'it saves the right logging information inner', has_user=false
       end
     end
 


### PR DESCRIPTION
this will reduce the overhead of updating the users last login, and means
we can avoid the logic for if the user doesn't exist