### PR TITLE
Ensure Sentry is reporting for both Rake and web requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,7 @@ require 'sinatra/json'
 require './lib/loader'
 
 class App < Sinatra::Base
+  use Raven::Rack if defined? Raven
   register Sinatra::SensibleLogging
 
   sensible_logging(


### PR DESCRIPTION
Sentry has to be configured differently for Rake and Sinatra.
Only 'use' Sentry for Sinatra when it's been defined for the correct
environment.