### PR TITLE
only bind ports in development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,3 +4,5 @@ services:
   app:
     volumes:
     - ".:/usr/src/app"
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,16 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: govwifi_test
-    ports:
-      - "13306:3306"
+    expose:
+      - "3306"
 
   user_db:
     build: ./mysql_user
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: govwifi_user_test
-    ports:
-      - "13307:3306"
+    expose:
+      - "3306"
 
   app:
     build: .
@@ -28,5 +28,5 @@ services:
       USER_DB_PASS: root
       USER_DB_USER: root
       USER_DB_HOSTNAME: user_db
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel