### PR TITLE
Run acceptance specs when a merge to master occurs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,17 @@ pipeline {
       }
     }
 
+    stage('Acceptance Tests') {
+      agent none
+      when {
+        branch 'master'
+        beforeAgent true
+      }
+      steps {
+        build 'govwifi-acceptance-tests/master'
+      }
+    }
+
     stage('Publish stable tag') {
       agent any
       when{


### PR DESCRIPTION
- When there is a merge to `logging-api/master` it triggers the `acceptance-tests/master` pipeline to be built.
- This runs the acceptance tests on all the dependent master branches.
- If it fails it blocks the deploy, but not the merge.

Exists in the `frontend` already here: https://github.com/alphagov/govwifi-frontend/blob/master/Jenkinsfile#L33