### PR TITLE
simply the package installation process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,9 @@ ENV S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY 'stub-key'
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN apk --update --upgrade add build-base mysql-dev && \
-  bundle check || ${BUNDLE_INSTALL_CMD} && \
-  apk del build-base && \
-  find / -type f -iname \*.apk-new -delete && \
-  rm -rf /var/cache/apk/*
+RUN apk --no-cache add build-base mysql-dev && \
+  ${BUNDLE_INSTALL_CMD} && \
+  apk del build-base
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ENV S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY 'stub-key'
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN apk --no-cache add build-base mysql-dev && \
+RUN apk --no-cache add --virtual .build-deps build-base && \
+  apk --no-cache add mysql-dev && \
   ${BUNDLE_INSTALL_CMD} && \
-  apk del build-base
+  apk del .build-deps
 
 COPY . .
 


### PR DESCRIPTION
- since alpine 3.3, we've been able to run apk in 'no-cache' mode.
  This handles cleanup for us, which means we can stop running the cleanup
  commands manually.

This specifically targets the 'find / ...' command, which fails when utilising
namespace remapping with Docker, as we get a 'Permission Denied' error when accessing
files in '/proc/'