### PR TITLE
Remove total key and value from active users performance platform stats

### DIFF
--- a/lib/performance_platform/gateway/active_users.rb
+++ b/lib/performance_platform/gateway/active_users.rb
@@ -8,8 +8,7 @@ class PerformancePlatform::Gateway::ActiveUsers
     result = repository.active_users_stats(period: period, date: date) || Hash.new(0)
 
     {
-      total: result[:total].to_i,
-      transactions: result[:total],
+      users: result[:total],
       metric_name: 'active-users',
       period: period
     }

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -10,8 +10,7 @@ class PerformancePlatform::Presenter::ActiveUsers
     {
       metric_name: stats[:metric_name],
       payload: [
-        as_hash(stats[:total], 'total'),
-        as_hash(stats[:transactions], 'transactions')
+        as_hash(stats[:users], 'users'),
       ]
     }
   end

--- a/spec/lib/performance_platform/gateway/active_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/active_users_spec.rb
@@ -28,8 +28,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'counts each user' do
         expect(result).to eq(
-          total: 2,
-          transactions: 2,
+          users: 2,
           metric_name: "active-users",
           period: "week"
         )
@@ -55,8 +54,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'counts each user only once' do
         expect(result).to eq(
-          total: 1,
-          transactions: 1,
+          users: 1,
           metric_name: "active-users",
           period: "week"
         )
@@ -82,8 +80,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'does not count the users outside the week' do
         expect(result).to eq(
-          total: 1,
-          transactions: 1,
+          users: 1,
           metric_name: "active-users",
           period: "week"
         )
@@ -109,8 +106,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'counts only the successful connections' do
         expect(result).to eq(
-          total: 1,
-          transactions: 1,
+          users: 1,
           metric_name: "active-users",
           period: "week"
         )
@@ -129,8 +125,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'only counts stats from the latest full day' do
         expect(result).to eq(
-          total: 0,
-          transactions: 0,
+          users: 0,
           metric_name: "active-users",
           period: "week"
         )
@@ -160,8 +155,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'counts each user' do
         expect(result).to eq(
-          total: 2,
-          transactions: 2,
+          users: 2,
           metric_name: "active-users",
           period: "month"
         )
@@ -187,8 +181,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'counts each user only once' do
         expect(result).to eq(
-          total: 1,
-          transactions: 1,
+          users: 1,
           metric_name: "active-users",
           period: "month"
         )
@@ -214,8 +207,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
 
       it 'does not count the users outside the month' do
         expect(result).to eq(
-          total: 0,
-          transactions: 0,
+          users: 0,
           metric_name: "active-users",
           period: "month"
         )

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -44,8 +44,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
     let(:stats_gateway) { PerformancePlatform::Gateway::ActiveUsers.new(period: 'week') }
     let(:stats_gateway_response) {
       {
-        total: 3,
-        transactions: 3,
+        users: 3,
         metric_name: 'active-users',
         period: 'week'
       }
@@ -56,19 +55,11 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         metric_name: 'active-users',
         payload: [
           {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3RvdGFs',
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3VzZXJz',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'active-users',
             period: 'week',
-            type: 'total',
-            count: 3
-          },
-          {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3RyYW5zYWN0aW9ucw==',
-            _timestamp: '2018-07-16T00:00:00+00:00',
-            dataType: 'active-users',
-            period: 'week',
-            type: 'transactions',
+            type: 'users',
             count: 3
           }
         ]


### PR DESCRIPTION
The total is no longer used and instead of `transactions` we now use `users`.