### PR TITLE
Roaming users

### DIFF
--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -27,7 +27,7 @@ private
   end
 
   def roaming_percentage
-    return 0 if active_users_results.fetch(:total) == 0
+    return 0 if active_users_results.fetch(:total).zero?
 
     roaming_users_results.fetch(:total_roaming).to_f / active_users_results.fetch(:total).to_f * 100
   end

--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -1,0 +1,36 @@
+class PerformancePlatform::Gateway::RoamingUsers
+  def initialize(period:, date: Date.today.to_s)
+    @period = period.to_s
+    @date = Date.parse(date)
+  end
+
+  def fetch_stats
+    {
+      percentage: roaming_percentage.round,
+      metric_name: 'roaming-users',
+      period: period
+    }
+  end
+
+private
+
+  def repository
+    PerformancePlatform::Repository::Session
+  end
+
+  def active_users_results
+    @active_users_results ||= repository.active_users_stats(period: period, date: date)
+  end
+
+  def roaming_users_results
+    repository.roaming_users_count(period: period, date: date)
+  end
+
+  def roaming_percentage
+    return 0 if active_users_results.fetch(:total) == 0
+
+    roaming_users_results.fetch(:total_roaming).to_f / active_users_results.fetch(:total).to_f * 100
+  end
+
+  attr_reader :period, :date
+end

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,4 +1,6 @@
 class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
+  # rubocop:disable Metrics/BlockLength
+
   dataset_module do
     def active_users_stats(period:, date:)
       DB.fetch("
@@ -38,4 +40,5 @@ class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
       DB.fetch(sql).first
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/lib/performance_platform/gateway/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/roaming_users_spec.rb
@@ -25,8 +25,8 @@ describe PerformancePlatform::Gateway::RoamingUsers do
       expect(subject.fetch_stats.fetch(:period)).to eq('week')
     end
 
-    context 'given all users have visited more than 1 location' do
-      it 'counts all of them as roaming' do
+    context 'given a user has visited more than 1 location' do
+      it 'counts as roaming' do
         create_session(ip_1, 'alice', yesterday)
         create_session(ip_2, 'alice', yesterday)
 
@@ -91,7 +91,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
     end
   end
 
-  private
+private
 
   def create_session(ip, username, start, success = 1)
     sessions.insert(siteIP: ip, username: username, start: start, success: success)

--- a/spec/lib/performance_platform/gateway/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/roaming_users_spec.rb
@@ -1,0 +1,99 @@
+describe PerformancePlatform::Gateway::RoamingUsers do
+  subject { described_class.new(period: period) }
+
+  let(:location_ip_links) { DB[:ip_locations] }
+  let(:sessions) { DB[:sessions] }
+  let(:ip_1) { '7.7.7.7' }
+  let(:ip_2) { '8.8.8.8' }
+  let(:yesterday) { Date.today - 1 }
+  let(:period) { 'week' }
+
+  before do
+    sessions.truncate
+    location_ip_links.truncate
+
+    location_ip_links.insert(ip: ip_1, location_id: 1)
+    location_ip_links.insert(ip: ip_2, location_id: 2)
+  end
+
+  it 'adds the metric name' do
+    expect(subject.fetch_stats.fetch(:metric_name)).to eq('roaming-users')
+  end
+
+  context 'weekly' do
+    it 'adds the period to the payload' do
+      expect(subject.fetch_stats.fetch(:period)).to eq('week')
+    end
+
+    context 'given all users have visited more than 1 location' do
+      it 'counts all of them as roaming' do
+        create_session(ip_1, 'alice', yesterday)
+        create_session(ip_2, 'alice', yesterday)
+
+        expect(subject.fetch_stats.fetch(:percentage)).to eq(100)
+      end
+    end
+
+    context 'given only some users have visited more than 1 location' do
+      it 'counts only those users as roaming' do
+        create_session(ip_1, 'alice', yesterday)
+        create_session(ip_2, 'alice', yesterday)
+        create_session(ip_1, 'sally', yesterday)
+        create_session(ip_1, 'john', yesterday)
+
+        expect(subject.fetch_stats.fetch(:percentage)).to eq(33)
+      end
+
+      context 'given users have only visited one location' do
+        it 'does not count them as roaming' do
+          create_session(ip_1, 'alice', yesterday)
+          create_session(ip_1, 'john', yesterday)
+
+          expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+        end
+      end
+    end
+
+    context 'given unsucessful logins' do
+      it 'does not count them as roaming' do
+        create_session(ip_1, 'alice', yesterday, 0)
+
+        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+      end
+    end
+  end
+
+  context 'outside the timeframe' do
+    context 'week' do
+      let(:period) { 'week' }
+
+      it 'does not count them as roaming' do
+        create_session(ip_1, 'alice', Date.today - 8)
+        create_session(ip_2, 'alice', Date.today - 8)
+
+        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+      end
+    end
+
+    context 'month' do
+      let(:period) { 'month' }
+
+      it 'adds the period to the payload' do
+        expect(subject.fetch_stats.fetch(:period)).to eq('month')
+      end
+
+      it 'does not count them as roaming' do
+        create_session(ip_1, 'alice', Date.today - 32)
+        create_session(ip_2, 'alice', Date.today - 32)
+
+        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+      end
+    end
+  end
+
+  private
+
+  def create_session(ip, username, start, success = 1)
+    sessions.insert(siteIP: ip, username: username, start: start, success: success)
+  end
+end


### PR DESCRIPTION
Add roaming user statistics

This new statistic will take the number of roaming users divided by the
number of active users.  This will be sent to the performance platform
as a new statistic.

The rake task doesn't call this yet.
