### PR TITLE
Modify roaming performance platform payload

### DIFF
--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -6,7 +6,8 @@ class PerformancePlatform::Gateway::RoamingUsers
 
   def fetch_stats
     {
-      percentage: roaming_percentage.round,
+      active: active_users_count,
+      roaming: roaming_users_count,
       metric_name: 'roaming-users',
       period: period
     }
@@ -18,18 +19,12 @@ private
     PerformancePlatform::Repository::Session
   end
 
-  def active_users_results
-    @active_users_results ||= repository.active_users_stats(period: period, date: date)
+  def active_users_count
+    repository.active_users_stats(period: period, date: date).fetch(:total)
   end
 
-  def roaming_users_results
-    repository.roaming_users_count(period: period, date: date)
-  end
-
-  def roaming_percentage
-    return 0 if active_users_results.fetch(:total).zero?
-
-    roaming_users_results.fetch(:total_roaming).to_f / active_users_results.fetch(:total).to_f * 100
+  def roaming_users_count
+    repository.roaming_users_count(period: period, date: date).fetch(:total_roaming)
   end
 
   attr_reader :period, :date

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -10,30 +10,37 @@ class PerformancePlatform::Presenter::RoamingUsers
     {
       metric_name: stats[:metric_name],
       payload: [
-        {
-          _id: encode_id,
-          _timestamp: timestamp,
-          dataType: stats[:metric_name],
-          period: stats[:period],
-          percentage: stats[:percentage]
-        }
+        as_hash(stats[:active], 'active'),
+        as_hash(stats[:roaming], 'roaming')
       ]
     }
   end
 
 private
 
+  def as_hash(count, type)
+    {
+      _id: encode_id(type),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      type: type,
+      count: count
+    }
+  end
+
   def generate_timestamp
     "#{date - 1}T00:00:00+00:00"
   end
 
-  def encode_id
+  def encode_id(type)
     Common::Base64.encode_array(
       [
         timestamp,
         ENV.fetch('PERFORMANCE_DATASET'),
         stats[:period],
-        stats[:metric_name]
+        stats[:metric_name],
+        type
       ]
     )
   end

--- a/spec/lib/performance_platform/gateway/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/roaming_users_spec.rb
@@ -30,7 +30,8 @@ describe PerformancePlatform::Gateway::RoamingUsers do
         create_session(ip_1, 'alice', yesterday)
         create_session(ip_2, 'alice', yesterday)
 
-        expect(subject.fetch_stats.fetch(:percentage)).to eq(100)
+        expect(subject.fetch_stats.fetch(:roaming)).to eq(1)
+        expect(subject.fetch_stats.fetch(:active)).to eq(1)
       end
     end
 
@@ -41,7 +42,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
         create_session(ip_1, 'sally', yesterday)
         create_session(ip_1, 'john', yesterday)
 
-        expect(subject.fetch_stats.fetch(:percentage)).to eq(33)
+        expect(subject.fetch_stats.fetch(:roaming)).to eq(1)
       end
 
       context 'given users have only visited one location' do
@@ -49,7 +50,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
           create_session(ip_1, 'alice', yesterday)
           create_session(ip_1, 'john', yesterday)
 
-          expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+          expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
         end
       end
     end
@@ -58,7 +59,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
       it 'does not count them as roaming' do
         create_session(ip_1, 'alice', yesterday, 0)
 
-        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+        expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end
     end
   end
@@ -71,7 +72,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
         create_session(ip_1, 'alice', Date.today - 8)
         create_session(ip_2, 'alice', Date.today - 8)
 
-        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+        expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end
     end
 
@@ -86,7 +87,7 @@ describe PerformancePlatform::Gateway::RoamingUsers do
         create_session(ip_1, 'alice', Date.today - 32)
         create_session(ip_2, 'alice', Date.today - 32)
 
-        expect(subject.fetch_stats.fetch(:percentage)).to eq(0)
+        expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end
     end
   end

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -1,0 +1,40 @@
+describe PerformancePlatform::Presenter::RoamingUsers do
+  before do
+    Timecop.freeze(Date.new(2018, 2, 1))
+    ENV['PERFORMANCE_DATASET'] = 'some-dataset'
+  end
+
+  let(:gateway_results) do
+    {
+      metric_name: 'some-metric-name',
+      roaming: 100,
+      active: 200,
+      period: 'week'
+    }
+  end
+
+  it 'presents the correct data' do
+    expected_result = {
+      metric_name: 'some-metric-name',
+      payload: [
+        {
+          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lYWN0aXZl",
+          _timestamp: "2018-01-31T00:00:00+00:00",
+          count: 200,
+          dataType: "some-metric-name",
+          period: "week",
+          type: "active"
+        }, {
+          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
+          _timestamp: "2018-01-31T00:00:00+00:00",
+          count: 100,
+          dataType: "some-metric-name",
+          period: "week",
+          type: "roaming"
+        }
+      ]
+    }
+
+    expect(subject.present(stats: gateway_results)).to eq(expected_result)
+  end
+end


### PR DESCRIPTION
We need to only send active users and roaming users stats.
The percentage will be calculated by the performance platform.