### PR TITLE
HOTFIX: stop updating last_login on the user table

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -85,7 +85,7 @@ module Logging
     def handle_username_request
       return true if username == 'HEALTH'
 
-      update_user_last_login unless access_reject?
+      # update_user_last_login unless access_reject?
       create_user_session
     end
   end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -118,7 +118,7 @@ describe App do
         context 'HEALTH user' do
           let(:username) { 'HEALTH' }
 
-          it 'does not update the last login' do
+          xit 'does not update the last login' do
             post_auth_request
             expect(user.last_login).to be_nil
           end
@@ -146,7 +146,7 @@ describe App do
 
       it_behaves_like 'it saves the right logging information'
 
-      it 'updates the user last login' do
+      xit 'updates the user last login' do
         post_auth_request
         expect(user.last_login).to_not be_nil
       end
@@ -174,7 +174,7 @@ describe App do
 
       it_behaves_like 'it saves the right logging information'
 
-      it 'does not update the user last login' do
+      xit 'does not update the user last login' do
         post_auth_request
         expect(user.last_login).to be_nil
       end


### PR DESCRIPTION
We're reached a critical point where this is causing major lag on the user database.

Disable this functionality for now.