### PR TITLE
change to using mysql 8 For the UserDB

### DIFF
--- a/mysql_user/Dockerfile
+++ b/mysql_user/Dockerfile
@@ -1,3 +1,5 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 ADD schema.sql /docker-entrypoint-initdb.d
+
+CMD [ "--default-authentication-plugin=mysql_native_password" ]


### PR DESCRIPTION
This matches our hosted environment.

We need to use mysql_native_password, as mariadb client doesn't ship with this yet