### PR TITLE
Adjust Batch deletion of old sessions to reduce RDS lag

### DIFF
--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -1,6 +1,7 @@
 require 'logger'
 
 class Gdpr::Gateway::Session
+  SESSIONBATCHSIZE = 500
   def delete_sessions
     logger = Logger.new(STDOUT)
 
@@ -8,7 +9,7 @@ class Gdpr::Gateway::Session
 
     total = 0
     loop do
-      deleted_rows = DB[:sessions].with_sql_delete('DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY) LIMIT 500')
+      deleted_rows = DB[:sessions].with_sql_delete("DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY) LIMIT #{SESSIONBATCHSIZE}")
       total += deleted_rows
 
       if deleted_rows == 0

--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -6,15 +6,17 @@ class Gdpr::Gateway::Session
 
     logger.info('Starting daily session deletion')
 
-    rows = Session.where(Sequel.lit('start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY')).count
+    total = 0
+    loop do
+      deleted_rows = DB[:sessions].with_sql_delete('DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY) LIMIT 500')
+      total += deleted_rows
 
-    i = 0
-    while i < rows
-      Session.where(Sequel.lit('start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY')).limit(100, i).delete
-      i += 100
+      if deleted_rows == 0
+        break
+      end
     end
 
-    logger.info("Finished daily session deletion, #{rows} rows affected")
+    logger.info("Finished daily session deletion, #{total} rows affected")
   end
 
   def active_users(date:)

--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -6,10 +6,15 @@ class Gdpr::Gateway::Session
 
     logger.info('Starting daily session deletion')
 
-    dataset = DB['DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY)']
-    rows_affected = dataset.delete
+    rows = Session.where(Sequel.lit('start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY')).count
 
-    logger.info("Finished daily session deletion, #{rows_affected} rows affected")
+    i = 0
+    while i < rows
+      Session.where(Sequel.lit('start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY')).limit(100, i).delete
+      i += 100
+    end
+
+    logger.info("Finished daily session deletion, #{rows} rows affected")
   end
 
   def active_users(date:)

--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -1,7 +1,7 @@
 require 'logger'
 
 class Gdpr::Gateway::Session
-  SESSIONBATCHSIZE = 500
+  SESSION_BATCH_SIZE = 500
   def delete_sessions
     logger = Logger.new(STDOUT)
 
@@ -9,10 +9,10 @@ class Gdpr::Gateway::Session
 
     total = 0
     loop do
-      deleted_rows = DB[:sessions].with_sql_delete("DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY) LIMIT #{SESSIONBATCHSIZE}")
+      deleted_rows = DB[:sessions].with_sql_delete("DELETE FROM sessions WHERE start < DATE_SUB(DATE(NOW()), INTERVAL 32 DAY) LIMIT #{SESSION_BATCH_SIZE}")
       total += deleted_rows
 
-      if deleted_rows == 0
+      if deleted_rows.zero?
         break
       end
     end


### PR DESCRIPTION
Currently when the deletion of old sessions happens, a lag
in RDS replication occurs, which in turn fires a cloudwatch
alarm.  As it self heals, this alarm is ignored but it does
create uneccessary noise which we have all become numb to.

We beleive the cause is because of how large the query is,
and that it creates a single large transaction log which
needs to be first copied across and fully replayed on the
replica, and during this replay the lag is created.

This PR breaks the session deletion query into batches of
100, with the intent to allow each batch to be replicated
and replayed on to the replica whilst other batches are
still being created on the master, thus dampening the
effect of the replication and reducing lag.

Pair: @smford & @rjbaker