### PR TITLE
Bau: fix upcoming linting errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
-source 'http://rubygems.org'
-ruby File.read('.ruby-version').chomp
+source "http://rubygems.org"
+ruby File.read(".ruby-version").chomp
 
-gem 'aws-sdk-s3', '~> 1'
-gem 'mysql2'
-gem 'puma'
-gem 'rake', '~> 13.0'
-gem 'require_all'
-gem 'sensible_logging', '~> 0.4.1'
-gem 'sentry-raven'
-gem 'sequel', '~> 5.33'
-gem 'sinatra'
-gem 'sinatra-contrib'
+gem "aws-sdk-s3", "~> 1"
+gem "mysql2"
+gem "puma"
+gem "rake", "~> 13.0"
+gem "require_all"
+gem "sensible_logging", "~> 0.4.1"
+gem "sentry-raven"
+gem "sequel", "~> 5.33"
+gem "sinatra"
+gem "sinatra-contrib"
 
 group :test do
-  gem 'govuk-lint'
-  gem 'rack-test'
-  gem 'rspec'
-  gem 'simplecov', require: false
-  gem 'timecop'
-  gem 'webmock'
+  gem "govuk-lint"
+  gem "rack-test"
+  gem "rspec"
+  gem "simplecov", require: false
+  gem "timecop"
+  gem "webmock"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require './lib/loader'
+require "./lib/loader"
 
-require './tasks/publish_statistics'
-require './tasks/session_deletion'
-require './tasks/update_last_login'
+require "./tasks/publish_statistics"
+require "./tasks/session_deletion"
+require "./tasks/update_last_login"

--- a/app.rb
+++ b/app.rb
@@ -17,7 +17,7 @@ class App < Sinatra::Base
       [
         req.body.read
       ].tap { req.body.rewind }
-    }]
+    }],
   )
 
   configure do

--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'sequel'
-require 'sensible_logging'
-require 'sinatra/base'
-require 'sinatra/json'
-require './lib/loader'
+require "sequel"
+require "sensible_logging"
+require "sinatra/base"
+require "sinatra/json"
+require "./lib/loader"
 
 class App < Sinatra::Base
   use Raven::Rack if defined? Raven
@@ -33,11 +33,11 @@ class App < Sinatra::Base
     set :log_level, Logger::INFO
   end
 
-  get '/healthcheck' do
-    'Healthy'
+  get "/healthcheck" do
+    "Healthy"
   end
 
-  post '/logging/post-auth' do
+  post "/logging/post-auth" do
     Logging::PostAuth.new.execute(params: JSON.parse(request.body.read))
 
     status 204

--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,7 @@ class App < Sinatra::Base
     log_tags: [->(req) {
       req.body.rewind
       [
-        req.body.read
+        req.body.read,
       ].tap { req.body.rewind }
     }],
   )

--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -1,11 +1,11 @@
-require 'logger'
+require "logger"
 
 class Gdpr::Gateway::Session
   SESSION_BATCH_SIZE = 500
   def delete_sessions
     logger = Logger.new(STDOUT)
 
-    logger.info('Starting daily session deletion')
+    logger.info("Starting daily session deletion")
 
     total = 0
     loop do
@@ -22,7 +22,7 @@ class Gdpr::Gateway::Session
 
   def active_users(date:)
     Session.select(:username).distinct
-      .where(Sequel.lit('DATE(start) = ?', date))
+      .where(Sequel.lit("DATE(start) = ?", date))
       .map(:username)
   end
 end

--- a/lib/gdpr/use_case/populate_user_last_login.rb
+++ b/lib/gdpr/use_case/populate_user_last_login.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 class Gdpr::UseCase::PopulateUserLastLogin
   def initialize(session_gateway:, last_login_gateway:)

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,34 +1,34 @@
-require 'base64'
-require 'sequel'
-require 'require_all'
-require 'net/http'
-require 'json'
+require "base64"
+require "sequel"
+require "require_all"
+require "net/http"
+require "json"
 
 DB = Sequel.connect(
-  adapter: 'mysql2',
-  host: ENV.fetch('DB_HOSTNAME'),
-  database: ENV.fetch('DB_NAME'),
-  user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS'),
+  adapter: "mysql2",
+  host: ENV.fetch("DB_HOSTNAME"),
+  database: ENV.fetch("DB_NAME"),
+  user: ENV.fetch("DB_USER"),
+  password: ENV.fetch("DB_PASS"),
   read_timeout: 9999,
   max_connections: 16,
 )
 
 USER_DB = Sequel.connect(
-  adapter: 'mysql2',
-  host: ENV.fetch('USER_DB_HOSTNAME'),
-  database: ENV.fetch('USER_DB_NAME'),
-  user: ENV.fetch('USER_DB_USER'),
-  password: ENV.fetch('USER_DB_PASS'),
+  adapter: "mysql2",
+  host: ENV.fetch("USER_DB_HOSTNAME"),
+  database: ENV.fetch("USER_DB_NAME"),
+  user: ENV.fetch("USER_DB_USER"),
+  password: ENV.fetch("USER_DB_PASS"),
   read_timeout: 9999,
   max_connections: 16,
 )
 
-if %w[production staging].include?(ENV['RACK_ENV'])
-  require 'raven'
+if %w[production staging].include?(ENV["RACK_ENV"])
+  require "raven"
 
   Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
+    config.dsn = ENV["SENTRY_DSN"]
   end
 end
 
@@ -47,4 +47,4 @@ module Gdpr
   module UseCase; end
 end
 
-require_all 'lib'
+require_all "lib"

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -32,7 +32,7 @@ if %w[production staging].include?(ENV["RACK_ENV"])
   end
 end
 
-module Common;
+module Common
 end
 
 module PerformancePlatform

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -43,7 +43,7 @@ module Logging
         ap: ap(@params.fetch("called_station_id")),
         siteIP: @params.fetch("site_ip_address"),
         building_identifier: building_identifier(@params.fetch("called_station_id")),
-        success: access_accept?
+        success: access_accept?,
       }
     end
 

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -31,8 +31,8 @@ module Logging
     def create_cert_session
       Session.create(
         session_params.merge(
-          cert_name: @params.fetch("cert_name")
-        )
+          cert_name: @params.fetch("cert_name"),
+        ),
       )
     end
 

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -3,7 +3,7 @@ module Logging
     def execute(params:)
       @params = params
 
-      return handle_username_request unless @params['cert_name'].present?
+      return handle_username_request unless @params["cert_name"].present?
 
       create_cert_session
     end
@@ -31,7 +31,7 @@ module Logging
     def create_cert_session
       Session.create(
         session_params.merge(
-          cert_name: @params.fetch('cert_name')
+          cert_name: @params.fetch("cert_name")
         )
       )
     end
@@ -39,24 +39,24 @@ module Logging
     def session_params
       {
         start: Time.now,
-        mac: formatted_mac(@params.fetch('mac')),
-        ap: ap(@params.fetch('called_station_id')),
-        siteIP: @params.fetch('site_ip_address'),
-        building_identifier: building_identifier(@params.fetch('called_station_id')),
+        mac: formatted_mac(@params.fetch("mac")),
+        ap: ap(@params.fetch("called_station_id")),
+        siteIP: @params.fetch("site_ip_address"),
+        building_identifier: building_identifier(@params.fetch("called_station_id")),
         success: access_accept?
       }
     end
 
     def access_reject?
-      @params.fetch('authentication_result') == 'Access-Reject'
+      @params.fetch("authentication_result") == "Access-Reject"
     end
 
     def access_accept?
-      @params.fetch('authentication_result') == 'Access-Accept'
+      @params.fetch("authentication_result") == "Access-Accept"
     end
 
     def username
-      @params.fetch('username')
+      @params.fetch("username")
     end
 
     def formatted_mac(unformatted_mac)
@@ -75,11 +75,11 @@ module Logging
       mac = formatted_mac(unformatted_mac)
       return mac if valid_mac?(mac)
 
-      ''
+      ""
     end
 
     def handle_username_request
-      return true if username == 'HEALTH'
+      return true if username == "HEALTH"
 
       create_user_session
     end

--- a/lib/mac_formatter.rb
+++ b/lib/mac_formatter.rb
@@ -10,7 +10,7 @@ private
   end
 
   def only_hex(mac)
-    mac.gsub(/[^0-F]/, '')
+    mac.gsub(/[^0-F]/, "")
   end
 
   def ietf_format(mac)

--- a/lib/performance_platform/gateway/active_users.rb
+++ b/lib/performance_platform/gateway/active_users.rb
@@ -10,7 +10,7 @@ class PerformancePlatform::Gateway::ActiveUsers
     {
       users: result[:total],
       metric_name: "active-users",
-      period: period
+      period: period,
     }
   end
 

--- a/lib/performance_platform/gateway/active_users.rb
+++ b/lib/performance_platform/gateway/active_users.rb
@@ -9,7 +9,7 @@ class PerformancePlatform::Gateway::ActiveUsers
 
     {
       users: result[:total],
-      metric_name: 'active-users',
+      metric_name: "active-users",
       period: period
     }
   end

--- a/lib/performance_platform/gateway/performance_report.rb
+++ b/lib/performance_platform/gateway/performance_report.rb
@@ -11,30 +11,30 @@ private
 
   def post(uri, data)
     request = Net::HTTP::Post.new(uri)
-    request['Authorization'] = build_bearer_token(data)
-    request['Content-Type'] = 'application/json'
+    request["Authorization"] = build_bearer_token(data)
+    request["Content-Type"] = "application/json"
     request.body = data[:payload].to_json
 
     Net::HTTP.start(uri.hostname, 443, use_ssl: true) do |http|
       response = http.request(request)
 
       raise PerformancePlatform::Gateway::HttpError, "#{response.code} - #{response.body}" \
-        unless response.code == '200'
+        unless response.code == "200"
 
       JSON.parse(response.body)
     end
   end
 
   def build_url(data)
-    performance_url = ENV.fetch('PERFORMANCE_URL')
-    dataset_name = ENV.fetch('PERFORMANCE_DATASET')
+    performance_url = ENV.fetch("PERFORMANCE_URL")
+    dataset_name = ENV.fetch("PERFORMANCE_DATASET")
     metric_name = data[:metric_name]
 
     URI("#{performance_url}data/#{dataset_name}/#{metric_name}")
   end
 
   def build_bearer_token(data)
-    bearer_const_name = data[:metric_name].tr('-', '_').upcase
+    bearer_const_name = data[:metric_name].tr("-", "_").upcase
 
     "Bearer #{ENV.fetch('PERFORMANCE_BEARER_' + bearer_const_name)}"
   end

--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -8,7 +8,7 @@ class PerformancePlatform::Gateway::RoamingUsers
     {
       active: active_users_count,
       roaming: roaming_users_count,
-      metric_name: 'roaming-users',
+      metric_name: "roaming-users",
       period: period
     }
   end

--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -9,7 +9,7 @@ class PerformancePlatform::Gateway::RoamingUsers
       active: active_users_count,
       roaming: roaming_users_count,
       metric_name: "roaming-users",
-      period: period
+      period: period,
     }
   end
 

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -1,13 +1,13 @@
-require 'aws-sdk-s3'
+require "aws-sdk-s3"
 
 class PerformancePlatform::Gateway::S3IpLocations
   def initialize
-    @s3 = Aws::S3::Client.new(region: 'eu-west-2')
+    @s3 = Aws::S3::Client.new(region: "eu-west-2")
   end
 
   def fetch
-    bucket = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_BUCKET')
-    key = ENV.fetch('S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY')
+    bucket = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_BUCKET")
+    key = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY")
 
     response = s3.get_object(bucket: bucket, key: key)
     JSON.parse(response.body.read)

--- a/lib/performance_platform/gateway/sequel_ip_locations.rb
+++ b/lib/performance_platform/gateway/sequel_ip_locations.rb
@@ -3,7 +3,7 @@ class PerformancePlatform::Gateway::SequelIPLocations
     truncate_ip_locations
 
     data = ip_locations.map do |ip_location|
-      [ip_location['ip'], ip_location['location_id']]
+      [ip_location["ip"], ip_location["location_id"]]
     end
 
     DB[:ip_locations].import(%i[ip location_id], data)

--- a/lib/performance_platform/gateway/unique_users.rb
+++ b/lib/performance_platform/gateway/unique_users.rb
@@ -8,7 +8,7 @@ class PerformancePlatform::Gateway::UniqueUsers
     {
       count: result[:count].to_i,
       metric_name: "unique-users",
-      period: period
+      period: period,
     }
   end
 

--- a/lib/performance_platform/gateway/unique_users.rb
+++ b/lib/performance_platform/gateway/unique_users.rb
@@ -7,7 +7,7 @@ class PerformancePlatform::Gateway::UniqueUsers
   def fetch_stats
     {
       count: result[:count].to_i,
-      metric_name: 'unique-users',
+      metric_name: "unique-users",
       period: period
     }
   end

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -11,7 +11,7 @@ class PerformancePlatform::Presenter::ActiveUsers
       metric_name: stats[:metric_name],
       payload: [
         as_hash(stats[:users], "users"),
-      ]
+      ],
     }
   end
 
@@ -28,7 +28,7 @@ private
       dataType: stats[:metric_name],
       period: stats[:period],
       type: type,
-      count: count
+      count: count,
     }
   end
 

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -10,7 +10,7 @@ class PerformancePlatform::Presenter::ActiveUsers
     {
       metric_name: stats[:metric_name],
       payload: [
-        as_hash(stats[:users], 'users'),
+        as_hash(stats[:users], "users"),
       ]
     }
   end
@@ -36,7 +36,7 @@ private
     Common::Base64.encode_array(
       [
         timestamp,
-        ENV.fetch('PERFORMANCE_DATASET'),
+        ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name],
         type

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -40,7 +40,7 @@ private
         stats[:period],
         stats[:metric_name],
         type
-      ]
+      ],
     )
   end
 

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -39,7 +39,7 @@ private
         ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name],
-        type
+        type,
       ],
     )
   end

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -41,7 +41,7 @@ private
         stats[:period],
         stats[:metric_name],
         type
-      ]
+      ],
     )
   end
 

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -11,7 +11,7 @@ class PerformancePlatform::Presenter::RoamingUsers
       metric_name: stats[:metric_name],
       payload: [
         as_hash(stats[:active], "active"),
-        as_hash(stats[:roaming], "roaming")
+        as_hash(stats[:roaming], "roaming"),
       ],
     }
   end
@@ -40,7 +40,7 @@ private
         ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name],
-        type
+        type,
       ],
     )
   end

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -12,7 +12,7 @@ class PerformancePlatform::Presenter::RoamingUsers
       payload: [
         as_hash(stats[:active], "active"),
         as_hash(stats[:roaming], "roaming")
-      ]
+      ],
     }
   end
 
@@ -25,7 +25,7 @@ private
       dataType: stats[:metric_name],
       period: stats[:period],
       type: type,
-      count: count
+      count: count,
     }
   end
 

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -10,8 +10,8 @@ class PerformancePlatform::Presenter::RoamingUsers
     {
       metric_name: stats[:metric_name],
       payload: [
-        as_hash(stats[:active], 'active'),
-        as_hash(stats[:roaming], 'roaming')
+        as_hash(stats[:active], "active"),
+        as_hash(stats[:roaming], "roaming")
       ]
     }
   end
@@ -37,7 +37,7 @@ private
     Common::Base64.encode_array(
       [
         timestamp,
-        ENV.fetch('PERFORMANCE_DATASET'),
+        ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name],
         type

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -34,7 +34,7 @@ private
         ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name]
-      ]
+      ],
     )
   end
 

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -15,9 +15,9 @@ class PerformancePlatform::Presenter::UniqueUsers
           _timestamp: timestamp,
           dataType: stats[:metric_name],
           period: stats[:period],
-          count_field_name => stats[:count]
+          count_field_name => stats[:count],
         }
-      ]
+      ],
     }
   end
 

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -16,7 +16,7 @@ class PerformancePlatform::Presenter::UniqueUsers
           dataType: stats[:metric_name],
           period: stats[:period],
           count_field_name => stats[:count],
-        }
+        },
       ],
     }
   end
@@ -33,7 +33,7 @@ private
         timestamp,
         ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
-        stats[:metric_name]
+        stats[:metric_name],
       ],
     )
   end

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -31,7 +31,7 @@ private
     Common::Base64.encode_array(
       [
         timestamp,
-        ENV.fetch('PERFORMANCE_DATASET'),
+        ENV.fetch("PERFORMANCE_DATASET"),
         stats[:period],
         stats[:metric_name]
       ]
@@ -39,7 +39,7 @@ private
   end
 
   def count_field_name
-    stats[:period] == 'month' ? 'month_count' : 'count'
+    stats[:period] == "month" ? "month_count" : "count"
   end
 
   attr_reader :stats, :timestamp, :date

--- a/lib/performance_platform/use_case/send_performance_report.rb
+++ b/lib/performance_platform/use_case/send_performance_report.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require "logger"
 
 class PerformancePlatform::UseCase::SendPerformanceReport
   def initialize(stats_gateway:, performance_gateway:, logger: Logger.new(STDOUT))

--- a/spec/features/certs_logging_spec.rb
+++ b/spec/features/certs_logging_spec.rb
@@ -4,8 +4,8 @@ describe App do
     USER_DB[:userdetails].truncate
   end
 
-  describe 'certificate post-auth logging with POST' do
-    shared_examples 'logging' do
+  describe "certificate post-auth logging with POST" do
+    shared_examples "logging" do
       let(:request_body) {
         {
           username: username,
@@ -17,37 +17,37 @@ describe App do
         }.to_json
       }
       let(:post_auth_request) { post "/logging/post-auth", request_body }
-      let(:cert_name) { 'Example Certificate Common Name' }
-      let(:authentication_result) { 'Access-Accept' }
+      let(:cert_name) { "Example Certificate Common Name" }
+      let(:authentication_result) { "Access-Accept" }
 
       before { post_auth_request }
 
-      it 'a session' do
+      it "a session" do
         expect(Session.count).to eq(1)
       end
 
-      it 'the certificate common name' do
-        expect(Session.first[:cert_name]).to eq('Example Certificate Common Name')
+      it "the certificate common name" do
+        expect(Session.first[:cert_name]).to eq("Example Certificate Common Name")
       end
     end
 
-    context 'with a blank username' do
-      let(:username) { '' }
+    context "with a blank username" do
+      let(:username) { "" }
 
-      it_behaves_like 'logging'
+      it_behaves_like "logging"
     end
 
-    context 'with a username' do
-      let(:username) { 'fakeusername' }
+    context "with a username" do
+      let(:username) { "fakeusername" }
 
-      it_behaves_like 'logging'
+      it_behaves_like "logging"
     end
   end
 
-  describe 'user/pass post-auth logging (on new endpoint)' do
-    let(:username) { 'ABCDE' }
-    let(:mac) { 'DA-59-19-8B-39-2D' }
-    let(:authentication_result) { 'Access-Accept' }
+  describe "user/pass post-auth logging (on new endpoint)" do
+    let(:username) { "ABCDE" }
+    let(:mac) { "DA-59-19-8B-39-2D" }
+    let(:authentication_result) { "Access-Accept" }
 
     let(:request_body) {
       {
@@ -66,11 +66,11 @@ describe App do
       post_auth_request
     end
 
-    it 'writes a session' do
+    it "writes a session" do
       expect(Session.count).to eq(1)
     end
 
-    it 'writes the mac address' do
+    it "writes the mac address" do
       expect(Session.first[:mac]).to eq(mac)
     end
   end

--- a/spec/features/certs_logging_spec.rb
+++ b/spec/features/certs_logging_spec.rb
@@ -13,7 +13,7 @@ describe App do
           mac: nil,
           called_station_id: nil,
           site_ip_address: nil,
-          authentication_result: authentication_result
+          authentication_result: authentication_result,
         }.to_json
       }
       let(:post_auth_request) { post "/logging/post-auth", request_body }
@@ -56,7 +56,7 @@ describe App do
         mac: mac,
         called_station_id: nil,
         site_ip_address: nil,
-        authentication_result: authentication_result
+        authentication_result: authentication_result,
       }.to_json
     }
     let(:post_auth_request) { post "/logging/post-auth", request_body }

--- a/spec/features/certs_logging_spec.rb
+++ b/spec/features/certs_logging_spec.rb
@@ -6,7 +6,7 @@ describe App do
 
   describe "certificate post-auth logging with POST" do
     shared_examples "logging" do
-      let(:request_body) {
+      let(:request_body) do
         {
           username: username,
           cert_name: cert_name,
@@ -15,7 +15,7 @@ describe App do
           site_ip_address: nil,
           authentication_result: authentication_result,
         }.to_json
-      }
+      end
       let(:post_auth_request) { post "/logging/post-auth", request_body }
       let(:cert_name) { "Example Certificate Common Name" }
       let(:authentication_result) { "Access-Accept" }
@@ -49,7 +49,7 @@ describe App do
     let(:mac) { "DA-59-19-8B-39-2D" }
     let(:authentication_result) { "Access-Accept" }
 
-    let(:request_body) {
+    let(:request_body) do
       {
         username: username,
         cert_name: nil,
@@ -58,7 +58,7 @@ describe App do
         site_ip_address: nil,
         authentication_result: authentication_result,
       }.to_json
-    }
+    end
     let(:post_auth_request) { post "/logging/post-auth", request_body }
 
     before do

--- a/spec/features/daily_session_deletion_spec.rb
+++ b/spec/features/daily_session_deletion_spec.rb
@@ -1,16 +1,16 @@
-describe 'daily session deletion' do
+describe "daily session deletion" do
   subject { Gdpr::UseCase::SessionDeletion.new(session_gateway: Gdpr::Gateway::Session.new) }
   let(:session) { DB[:sessions] }
 
-  context 'Given sessions older than 3 months' do
+  context "Given sessions older than 3 months" do
     before do
       session.delete
-      session.insert(start: Date.today, username: 'bob')
-      session.insert(start: Date.today, username: 'sally')
-      session.insert(start: Date.today - 120, username: 'george')
+      session.insert(start: Date.today, username: "bob")
+      session.insert(start: Date.today, username: "sally")
+      session.insert(start: Date.today - 120, username: "george")
     end
 
-    it 'deletes the session' do
+    it "deletes the session" do
       subject.execute
       expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
     end

--- a/spec/features/daily_session_deletion_spec.rb
+++ b/spec/features/daily_session_deletion_spec.rb
@@ -12,7 +12,7 @@ describe "daily session deletion" do
 
     it "deletes the session" do
       subject.execute
-      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w[bob sally])
     end
   end
 end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -17,7 +17,7 @@ describe App do
         mac: mac,
         called_station_id: called_station_id,
         site_ip_address: site_ip_address,
-        authentication_result: authentication_result
+        authentication_result: authentication_result,
       }.to_json
     }
     let(:post_auth_request) { post "/logging/post-auth", request_body }

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -4,12 +4,12 @@ describe App do
     USER_DB[:userdetails].truncate
   end
 
-  describe 'POST post-auth' do
-    let(:username) { 'VYKZDX' }
-    let(:mac) { 'DA-59-19-8B-39-2D' }
-    let(:called_station_id) { '01-39-38-25-2A-80' }
-    let(:site_ip_address) { '93.11.238.187' }
-    let(:cert_name) { '' }
+  describe "POST post-auth" do
+    let(:username) { "VYKZDX" }
+    let(:mac) { "DA-59-19-8B-39-2D" }
+    let(:called_station_id) { "01-39-38-25-2A-80" }
+    let(:site_ip_address) { "93.11.238.187" }
+    let(:cert_name) { "" }
     let(:request_body) {
       {
         username: username,
@@ -29,33 +29,33 @@ describe App do
       post_auth_request
     end
 
-    shared_examples 'it saves the right logging information' do
-      context 'GovWifi user' do
-        it 'creates a single session record' do
+    shared_examples "it saves the right logging information" do
+      context "GovWifi user" do
+        it "creates a single session record" do
           expect(Session.count).to eq(1)
         end
 
-        context 'given a certificate authentication' do
-          let(:cert_name) { 'some_cert_name' }
+        context "given a certificate authentication" do
+          let(:cert_name) { "some_cert_name" }
 
-          it 'records the cert name' do
+          it "records the cert name" do
             expect(session.cert_name).to eq(cert_name)
           end
         end
 
-        context 'given a lowercase username' do
-          let(:username) { 'abcdef' }
+        context "given a lowercase username" do
+          let(:username) { "abcdef" }
 
-          it 'ensures that the username is saved in uppercase' do
-            expect(session.username).to eq('ABCDEF')
+          it "ensures that the username is saved in uppercase" do
+            expect(session.username).to eq("ABCDEF")
           end
         end
 
-        it 'records the start time of the session' do
+        it "records the start time of the session" do
           expect(session.start).to_not be_nil
         end
 
-        it 'records the session details' do
+        it "records the session details" do
           expect(session.username).to eq(username)
           expect(session.mac).to eq(mac)
           expect(session.ap).to eq(called_station_id)
@@ -63,133 +63,133 @@ describe App do
         end
 
         context 'Given the "Called Station ID" is an MAC address' do
-          let(:called_station_id) { '01-39-38-25-2A-80' }
+          let(:called_station_id) { "01-39-38-25-2A-80" }
 
-          it 'saves it as the access point' do
+          it "saves it as the access point" do
             expect(session.ap).to eq(called_station_id)
           end
 
-          it 'does not save it as the building identifier' do
+          it "does not save it as the building identifier" do
             expect(session.building_identifier).to be_nil
           end
 
-          context 'Given the Called Station ID needs to be formatted' do
-            let(:called_station_id) { 'aa-bb-cc-25-2a-80' }
+          context "Given the Called Station ID needs to be formatted" do
+            let(:called_station_id) { "aa-bb-cc-25-2a-80" }
 
-            it 'formats the Called Station ID' do
-              expect(session.ap).to eq('AA-BB-CC-25-2A-80')
+            it "formats the Called Station ID" do
+              expect(session.ap).to eq("AA-BB-CC-25-2A-80")
             end
           end
 
-          context 'Given a Called Station ID has extra trailing characters' do
-            let(:called_station_id) { 'C4-13-E2-22-DC-55%3ASTAGING-GovWifi' }
+          context "Given a Called Station ID has extra trailing characters" do
+            let(:called_station_id) { "C4-13-E2-22-DC-55%3ASTAGING-GovWifi" }
 
-            it 'Formats it and considers it a valid access point' do
-              expect(session.ap).to eq('C4-13-E2-22-DC-55')
+            it "Formats it and considers it a valid access point" do
+              expect(session.ap).to eq("C4-13-E2-22-DC-55")
               expect(session.building_identifier).to be_nil
             end
           end
         end
 
         context 'Given the "Called Station ID" is a building identifier' do
-          let(:called_station_id) { 'Building-Identifier' }
+          let(:called_station_id) { "Building-Identifier" }
 
-          it 'saves it as a building identifier' do
+          it "saves it as a building identifier" do
             expect(session.building_identifier).to eq(called_station_id)
           end
 
-          it 'does not save it as an access point' do
-            expect(session.ap).to eq('')
+          it "does not save it as an access point" do
+            expect(session.ap).to eq("")
           end
         end
 
         context 'Given a blank "Called Station ID"' do
-          let(:called_station_id) { '' }
+          let(:called_station_id) { "" }
 
-          it 'does not save the ap' do
-            expect(session.ap).to eq('')
+          it "does not save the ap" do
+            expect(session.ap).to eq("")
           end
 
-          it 'does not save the building_identifier' do
+          it "does not save the building_identifier" do
             expect(session.building_identifier).to be_empty
           end
         end
 
-        context 'HEALTH user' do
-          let(:username) { 'HEALTH' }
+        context "HEALTH user" do
+          let(:username) { "HEALTH" }
 
-          it 'returns a 204 status code' do
+          it "returns a 204 status code" do
             expect(last_response.status).to eq(204)
           end
 
-          it 'does not create a session record' do
+          it "does not create a session record" do
             expect(Session.count).to eq(0)
           end
         end
       end
 
-      context 'MAC Formatter' do
-        let(:mac) { '50a67f849cd1' }
-        it 'saves the MAC formatted' do
-          expect(Session.last.mac).to eq('50-A6-7F-84-9C-D1')
+      context "MAC Formatter" do
+        let(:mac) { "50a67f849cd1" }
+        it "saves the MAC formatted" do
+          expect(Session.last.mac).to eq("50-A6-7F-84-9C-D1")
         end
       end
     end
 
-    context 'Access-Accept' do
-      let(:authentication_result) { 'Access-Accept' }
+    context "Access-Accept" do
+      let(:authentication_result) { "Access-Accept" }
 
-      it_behaves_like 'it saves the right logging information'
+      it_behaves_like "it saves the right logging information"
 
-      it 'sets success to true' do
+      it "sets success to true" do
         post_auth_request
         expect(Session.last.success).to eq(true)
       end
 
-      context 'Without a user in the database' do
+      context "Without a user in the database" do
         let!(:create_user) { nil }
 
-        it 'has not updated a non-existent user' do
+        it "has not updated a non-existent user" do
           expect(user).to be_nil
         end
 
-        it 'sets success to true' do
+        it "sets success to true" do
           expect(Session.last.success).to eq(true)
         end
       end
     end
 
-    context 'Access-Reject' do
-      let(:authentication_result) { 'Access-Reject' }
+    context "Access-Reject" do
+      let(:authentication_result) { "Access-Reject" }
 
-      it_behaves_like 'it saves the right logging information'
+      it_behaves_like "it saves the right logging information"
 
-      it 'sets success to false' do
+      it "sets success to false" do
         post_auth_request
         expect(Session.last.success).to eq(false)
       end
     end
 
-    context 'Invalid authentication result' do
-      context 'Given parameters are missing from the GET request' do
-        let(:authentication_result) { 'Access-Accept' }
-        let(:username) { '' }
-        let(:called_station_id) { '' }
-        let(:site_ip_address) { '' }
+    context "Invalid authentication result" do
+      context "Given parameters are missing from the GET request" do
+        let(:authentication_result) { "Access-Accept" }
+        let(:username) { "" }
+        let(:called_station_id) { "" }
+        let(:site_ip_address) { "" }
 
-        it 'returns a 204 status code' do
+        it "returns a 204 status code" do
           expect(last_response.status).to eq(204)
         end
 
-        it 'creates a session record' do
+        it "creates a session record" do
           expect(Session.all.count).to eq(1)
         end
       end
     end
   end
 
-  context 'given a username longer than 6 characters' do
-    it 'stops the error from blowing up' do
+  context "given a username longer than 6 characters" do
+    it "stops the error from blowing up" do
       username = "very_long_username"
       expect { get "/logging/post-auth/user/#{username}/cert-name//mac//ap//site//result/success" }.to_not raise_error
     end

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -10,7 +10,7 @@ describe App do
     let(:called_station_id) { "01-39-38-25-2A-80" }
     let(:site_ip_address) { "93.11.238.187" }
     let(:cert_name) { "" }
-    let(:request_body) {
+    let(:request_body) do
       {
         username: username,
         cert_name: cert_name,
@@ -19,7 +19,7 @@ describe App do
         site_ip_address: site_ip_address,
         authentication_result: authentication_result,
       }.to_json
-    }
+    end
     let(:post_auth_request) { post "/logging/post-auth", request_body }
     let!(:create_user) { User.create(username: username) }
     let(:user) { User.find(username: username) }

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -48,14 +48,14 @@ describe "synchronizing IPs and locations" do
           ip: "127.0.0.1",
           location_id: 1,
         },
-{
-          ip: "186.3.1.1",
-          location_id: 2,
-        },
-{
-          ip: "186.3.4.6",
-          location_id: 3,
-        },
+        {
+                  ip: "186.3.1.1",
+                  location_id: 2,
+                },
+        {
+                  ip: "186.3.4.6",
+                  location_id: 3,
+                },
       ]
     end
 

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -55,7 +55,7 @@ describe "synchronizing IPs and locations" do
 {
           ip: "186.3.4.6",
           location_id: 3,
-        }
+        },
       ]
     end
 

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -49,13 +49,13 @@ describe "synchronizing IPs and locations" do
           location_id: 1,
         },
         {
-                  ip: "186.3.1.1",
+          ip: "186.3.1.1",
                   location_id: 2,
-                },
+        },
         {
-                  ip: "186.3.4.6",
+          ip: "186.3.4.6",
                   location_id: 3,
-                },
+        },
       ]
     end
 

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -7,8 +7,8 @@ describe "synchronizing IPs and locations" do
 
     Aws.config = {
       stub_responses: {
-        get_object: { body: object_content.to_json }
-      }
+        get_object: { body: object_content.to_json },
+      },
     }
 
     ip_locations.truncate
@@ -46,15 +46,15 @@ describe "synchronizing IPs and locations" do
       [
         {
           ip: "127.0.0.1",
-          location_id: 1
+          location_id: 1,
         }, 
 {
           ip: "186.3.1.1",
-          location_id: 2
+          location_id: 2,
         }, 
 {
           ip: "186.3.4.6",
-          location_id: 3
+          location_id: 3,
         }
       ]
     end

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -47,11 +47,11 @@ describe "synchronizing IPs and locations" do
         {
           ip: "127.0.0.1",
           location_id: 1,
-        }, 
+        },
 {
           ip: "186.3.1.1",
           location_id: 2,
-        }, 
+        },
 {
           ip: "186.3.4.6",
           location_id: 3,

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -1,9 +1,9 @@
-describe 'synchronizing IPs and locations' do
+describe "synchronizing IPs and locations" do
   let(:ip_locations) { DB[:ip_locations] }
 
   before do
-    ENV['S3_PUBLISHED_LOCATIONS_IPS_BUCKET'] = 'stub-bucket'
-    ENV['S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY'] = 'stub-key'
+    ENV["S3_PUBLISHED_LOCATIONS_IPS_BUCKET"] = "stub-bucket"
+    ENV["S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY"] = "stub-key"
 
     Aws.config = {
       stub_responses: {
@@ -23,49 +23,49 @@ describe 'synchronizing IPs and locations' do
     )
   end
 
-  context 'no IPs/locations are in source' do
+  context "no IPs/locations are in source" do
     let(:object_content) { [] }
 
-    it 'saves empty IPs and locations' do
+    it "saves empty IPs and locations" do
       subject.execute
       expect(ip_locations.count).to be_zero
     end
 
-    context 'with existing IPs and locations in the database' do
+    context "with existing IPs and locations in the database" do
       before { ip_locations.insert(ip: 1, location_id: 1) }
 
-      it 'overwrites them' do
+      it "overwrites them" do
         subject.execute
         expect(ip_locations.count).to be_zero
       end
     end
   end
 
-  context 'three IPs and locations are in source' do
+  context "three IPs and locations are in source" do
     let(:object_content) do
       [
         {
-          ip: '127.0.0.1',
+          ip: "127.0.0.1",
           location_id: 1
         }, {
-          ip: '186.3.1.1',
+          ip: "186.3.1.1",
           location_id: 2
         }, {
-          ip: '186.3.4.6',
+          ip: "186.3.4.6",
           location_id: 3
         }
       ]
     end
 
-    it 'saves three IPs and locations' do
+    it "saves three IPs and locations" do
       subject.execute
       expect(ip_locations.count).to eq(3)
     end
 
-    context 'with existing IPs and locations in the database' do
-      before { ip_locations.insert(ip: '186.3.1.1', location_id: 1) }
+    context "with existing IPs and locations in the database" do
+      before { ip_locations.insert(ip: "186.3.1.1", location_id: 1) }
 
-      it 'overwrites them instead of adding to them' do
+      it "overwrites them instead of adding to them" do
         subject.execute
         expect(ip_locations.count).to eq 3
       end

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -47,10 +47,12 @@ describe "synchronizing IPs and locations" do
         {
           ip: "127.0.0.1",
           location_id: 1
-        }, {
+        }, 
+{
           ip: "186.3.1.1",
           location_id: 2
-        }, {
+        }, 
+{
           ip: "186.3.4.6",
           location_id: 3
         }

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -19,7 +19,7 @@ describe "synchronizing IPs and locations" do
     destination_gateway = PerformancePlatform::Gateway::SequelIPLocations.new
     PerformancePlatform::UseCase::SynchronizeIpLocations.new(
       source_gateway: source_gateway,
-      destination_gateway: destination_gateway
+      destination_gateway: destination_gateway,
     )
   end
 

--- a/spec/features/publish_daily_statistics_spec.rb
+++ b/spec/features/publish_daily_statistics_spec.rb
@@ -50,11 +50,11 @@ describe "synchronizing IPs and locations" do
         },
         {
           ip: "186.3.1.1",
-                  location_id: 2,
+          location_id: 2,
         },
         {
           ip: "186.3.4.6",
-                  location_id: 3,
+          location_id: 3,
         },
       ]
     end

--- a/spec/lib/common/base64_spec.rb
+++ b/spec/lib/common/base64_spec.rb
@@ -1,7 +1,7 @@
 describe Common::Base64 do
   context "#encode_array" do
     it "joins array contents and encodes it" do
-      arr = %w(foo bar baz)
+      arr = %w[foo bar baz]
 
       expect(described_class.encode_array(arr)).to eq("Zm9vYmFyYmF6")
     end

--- a/spec/lib/common/base64_spec.rb
+++ b/spec/lib/common/base64_spec.rb
@@ -1,9 +1,9 @@
 describe Common::Base64 do
-  context '#encode_array' do
-    it 'joins array contents and encodes it' do
+  context "#encode_array" do
+    it "joins array contents and encodes it" do
       arr = %w(foo bar baz)
 
-      expect(described_class.encode_array(arr)).to eq('Zm9vYmFyYmF6')
+      expect(described_class.encode_array(arr)).to eq("Zm9vYmFyYmF6")
     end
   end
 end

--- a/spec/lib/gdpr/gateway/session_active_users_spec.rb
+++ b/spec/lib/gdpr/gateway/session_active_users_spec.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 describe Gdpr::Gateway::Session do
   let(:subject) { described_class.new }
@@ -10,37 +10,37 @@ describe Gdpr::Gateway::Session do
     session.truncate
   end
 
-  context 'Without any session data' do
-    it 'finds no usernames' do
+  context "Without any session data" do
+    it "finds no usernames" do
       expect(subject.active_users(date: today)).to eq([])
     end
   end
 
-  context 'With session data' do
-    let(:username_today) { 'bob' }
-    let(:username_yesterday) { 'alice' }
+  context "With session data" do
+    let(:username_today) { "bob" }
+    let(:username_yesterday) { "alice" }
 
     before do
       2.times { session.insert(start: today, username: username_today) }
       2.times { session.insert(start: yesterday, username: username_yesterday) }
     end
 
-    context 'when searching through todays sessions' do
-      it 'finds todays username' do
+    context "when searching through todays sessions" do
+      it "finds todays username" do
         expect(subject.active_users(date: today)).to include(username_today)
       end
 
-      it 'does not find yesterdays username' do
+      it "does not find yesterdays username" do
         expect(subject.active_users(date: today)).not_to include(username_yesterday)
       end
     end
 
-    context 'when searching through yesterdays sessions' do
-      it 'finds yesterdays username' do
+    context "when searching through yesterdays sessions" do
+      it "finds yesterdays username" do
         expect(subject.active_users(date: yesterday)).to include(username_yesterday)
       end
 
-      it 'does not find todays username' do
+      it "does not find todays username" do
         expect(subject.active_users(date: yesterday)).not_to include(username_today)
       end
     end

--- a/spec/lib/gdpr/gateway/session_spec.rb
+++ b/spec/lib/gdpr/gateway/session_spec.rb
@@ -2,38 +2,38 @@ describe Gdpr::Gateway::Session do
   let(:session) { DB[:sessions] }
   before { session.delete }
 
-  context 'Given some sessions are older than 32 days' do
+  context "Given some sessions are older than 32 days" do
     before do
-      session.insert(start: Date.today, username: 'bob')
-      session.insert(start: Date.today, username: 'sally')
-      session.insert(start: Date.today - 33, username: 'george')
+      session.insert(start: Date.today, username: "bob")
+      session.insert(start: Date.today, username: "sally")
+      session.insert(start: Date.today - 33, username: "george")
     end
 
-    it 'deletes the old sessions' do
+    it "deletes the old sessions" do
       subject.delete_sessions
       expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
     end
   end
 
-  context 'Given all sessions are recent' do
+  context "Given all sessions are recent" do
     before do
-      session.insert(start: Date.today, username: 'sally')
-      session.insert(start: Date.today, username: 'george')
+      session.insert(start: Date.today, username: "sally")
+      session.insert(start: Date.today, username: "george")
     end
 
-    it 'does not delete the sessions' do
+    it "does not delete the sessions" do
       subject.delete_sessions
       expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(sally george))
     end
   end
 
-  context 'Given all sessions are old' do
+  context "Given all sessions are old" do
     before do
-      session.insert(start: Date.today - 33, username: 'Adam')
-      session.insert(start: Date.today - 33, username: 'Betty')
+      session.insert(start: Date.today - 33, username: "Adam")
+      session.insert(start: Date.today - 33, username: "Betty")
     end
 
-    it 'deletes the sessions' do
+    it "deletes the sessions" do
       subject.delete_sessions
       expect(session.all.map { |s| s.fetch(:username) }).to be_empty
     end

--- a/spec/lib/gdpr/gateway/session_spec.rb
+++ b/spec/lib/gdpr/gateway/session_spec.rb
@@ -11,7 +11,7 @@ describe Gdpr::Gateway::Session do
 
     it "deletes the old sessions" do
       subject.delete_sessions
-      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(bob sally))
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w[bob sally])
     end
   end
 
@@ -23,7 +23,7 @@ describe Gdpr::Gateway::Session do
 
     it "does not delete the sessions" do
       subject.delete_sessions
-      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w(sally george))
+      expect(session.all.map { |s| s.fetch(:username) }).to eq(%w[sally george])
     end
   end
 

--- a/spec/lib/gdpr/gateway/set_last_login_spec.rb
+++ b/spec/lib/gdpr/gateway/set_last_login_spec.rb
@@ -1,8 +1,8 @@
-require 'date'
+require "date"
 
 describe Gdpr::Gateway::SetLastLogin do
   let(:subject) { described_class.new }
-  let(:username) { 'borris' }
+  let(:username) { "borris" }
   let(:today) { Date.today }
   let(:yesterday) { today.prev_day }
   let(:tomorrow) { today.next_day }
@@ -12,22 +12,22 @@ describe Gdpr::Gateway::SetLastLogin do
     USER_DB[:userdetails].truncate
   end
 
-  context 'with a username' do
+  context "with a username" do
     let(:current_last_login) { nil }
     before do
       userdetails.insert(username: username, last_login: current_last_login)
     end
 
-    it 'sets the last_login date' do
+    it "sets the last_login date" do
       subject.set(date: today, usernames: [username])
       expect(userdetails.first(username: username)[:last_login].to_date).to eq(today)
     end
 
-    context 'when last_login already set' do
-      context 'when last_login is currently in the past' do
+    context "when last_login already set" do
+      context "when last_login is currently in the past" do
         let(:current_last_login) { yesterday }
 
-        it 'updates last_login' do
+        it "updates last_login" do
           subject.set(date: today, usernames: [username])
           expect(userdetails.first(username: username)[:last_login].to_date).to eq(today)
         end
@@ -35,8 +35,8 @@ describe Gdpr::Gateway::SetLastLogin do
     end
   end
 
-  context 'without any sessions' do
-    it 'does not fail' do
+  context "without any sessions" do
+    it "does not fail" do
       expect { subject.set(date: today, usernames: [username]) }.not_to raise_error
     end
   end

--- a/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
+++ b/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 describe Gdpr::UseCase::PopulateUserLastLogin do
   let(:subject) do
@@ -20,14 +20,14 @@ describe Gdpr::UseCase::PopulateUserLastLogin do
     userdetails.truncate
   end
 
-  context 'with no user sessions' do
-    it 'Does not fail' do
+  context "with no user sessions" do
+    it "Does not fail" do
       expect { subject.execute(date: today) }.not_to raise_error
     end
   end
 
-  context 'with user sessions' do
-    let(:username) { 'jacob' }
+  context "with user sessions" do
+    let(:username) { "jacob" }
     let(:current_last_login) { nil }
     let(:session_date) { today }
 
@@ -40,41 +40,41 @@ describe Gdpr::UseCase::PopulateUserLastLogin do
       userdetails.first(username: username)
     end
 
-    context 'when the user logs in for the first time' do
+    context "when the user logs in for the first time" do
       let(:current_last_login) { nil }
       let(:session_date) { today }
 
-      it 'sets the last_login date to today' do
+      it "sets the last_login date to today" do
         subject.execute(date: today)
         expect(user[:last_login].to_date).to eq(today)
       end
     end
 
-    context 'when the user was logged in yesterday' do
+    context "when the user was logged in yesterday" do
       let(:current_last_login) { yesterday }
       let(:session_date) { today }
 
-      it 'sets the last_login date to today' do
+      it "sets the last_login date to today" do
         subject.execute(date: today)
         expect(user[:last_login].to_date).to eq(today)
       end
     end
 
-    context 'when the user was last logged in today' do
+    context "when the user was last logged in today" do
       let(:current_last_login) { today }
       let(:session_date) { today }
 
-      it 'sets the last_login date to today' do
+      it "sets the last_login date to today" do
         subject.execute(date: today)
         expect(user[:last_login].to_date).to eq(today)
       end
     end
 
-    context 'when backfilling last logins' do
+    context "when backfilling last logins" do
       let(:current_last_login) { today }
       let(:session_date) { yesterday }
 
-      it 'does overrides the last login' do
+      it "does overrides the last login" do
         subject.execute(date: yesterday)
         expect(user[:last_login].to_date).to eq(yesterday)
       end

--- a/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
+++ b/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
@@ -4,7 +4,7 @@ describe Gdpr::UseCase::PopulateUserLastLogin do
   let(:subject) do
     described_class.new(
       session_gateway: Gdpr::Gateway::Session.new,
-      last_login_gateway: Gdpr::Gateway::SetLastLogin.new
+      last_login_gateway: Gdpr::Gateway::SetLastLogin.new,
     )
   end
 

--- a/spec/lib/gdpr/use_case/session_deletion_spec.rb
+++ b/spec/lib/gdpr/use_case/session_deletion_spec.rb
@@ -1,7 +1,7 @@
 describe Gdpr::UseCase::SessionDeletion do
   subject do
     described_class.new(
-      session_gateway: session_gateway
+      session_gateway: session_gateway,
     )
   end
 

--- a/spec/lib/gdpr/use_case/session_deletion_spec.rb
+++ b/spec/lib/gdpr/use_case/session_deletion_spec.rb
@@ -7,8 +7,8 @@ describe Gdpr::UseCase::SessionDeletion do
 
   let(:session_gateway) { double(delete_sessions: nil) }
 
-  context 'Given a session gateway' do
-    it 'calls delete_sessions on the gateway' do
+  context "Given a session gateway" do
+    it "calls delete_sessions on the gateway" do
       subject.execute
       expect(session_gateway).to have_received(:delete_sessions)
     end

--- a/spec/lib/mac_formatter_spec.rb
+++ b/spec/lib/mac_formatter_spec.rb
@@ -1,59 +1,59 @@
 describe MacFormatter do
-  it 'preserves a correctly formatted MAC' do
-    mac = '50-A6-7F-84-9C-D1'
+  it "preserves a correctly formatted MAC" do
+    mac = "50-A6-7F-84-9C-D1"
     result = subject.execute(mac: mac)
-    expect(result).to eq('50-A6-7F-84-9C-D1')
+    expect(result).to eq("50-A6-7F-84-9C-D1")
   end
 
-  it 'ensures that a MAC is all capital letters' do
-    mac = '50-a6-7f-84-9c-d1'
+  it "ensures that a MAC is all capital letters" do
+    mac = "50-a6-7f-84-9c-d1"
     result = subject.execute(mac: mac)
-    expect(result).to eq('50-A6-7F-84-9C-D1')
+    expect(result).to eq("50-A6-7F-84-9C-D1")
   end
 
-  it 'ensures all characters are separated by dashes' do
-    mac = '50A67F849CD1'
+  it "ensures all characters are separated by dashes" do
+    mac = "50A67F849CD1"
     result = subject.execute(mac: mac)
-    expect(result).to eq('50-A6-7F-84-9C-D1')
+    expect(result).to eq("50-A6-7F-84-9C-D1")
   end
 
-  it 'ensures the rest of the characters are separated by dashes' do
-    mac = '50-A67F849CD1'
+  it "ensures the rest of the characters are separated by dashes" do
+    mac = "50-A67F849CD1"
     result = subject.execute(mac: mac)
-    expect(result).to eq('50-A6-7F-84-9C-D1')
+    expect(result).to eq("50-A6-7F-84-9C-D1")
   end
 
-  it 'trims off excess characters' do
-    mac = '50A67F849CD1FF'
+  it "trims off excess characters" do
+    mac = "50A67F849CD1FF"
     result = subject.execute(mac: mac)
-    expect(result).to eq('50-A6-7F-84-9C-D1')
+    expect(result).to eq("50-A6-7F-84-9C-D1")
   end
 
-  it 'not enough characters' do
-    mac = 'fff333'
+  it "not enough characters" do
+    mac = "fff333"
     result = subject.execute(mac: mac)
-    expect(result).to eq('FF-F3-33---')
+    expect(result).to eq("FF-F3-33---")
   end
 
-  it 'no valid characters' do
-    mac = 'gggiiijjj'
+  it "no valid characters" do
+    mac = "gggiiijjj"
     result = subject.execute(mac: mac)
-    expect(result).to eq('-----')
+    expect(result).to eq("-----")
   end
 
-  it 'formats a mac with a nil value' do
+  it "formats a mac with a nil value" do
     mac = nil
     result = subject.execute(mac: mac)
-    expect(result).to eq('-----')
+    expect(result).to eq("-----")
   end
 
-  it 'some valid characters' do
-    mac = 'fffiiijjj'
+  it "some valid characters" do
+    mac = "fffiiijjj"
     result = subject.execute(mac: mac)
-    expect(result).to eq('FF-F----')
+    expect(result).to eq("FF-F----")
   end
 
-  it 'Throws an error when no MAC argument is supplied' do
+  it "Throws an error when no MAC argument is supplied" do
     expect { subject.execute }.to raise_error(ArgumentError)
   end
 end

--- a/spec/lib/performance_platform/gateway/active_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/active_users_spec.rb
@@ -15,14 +15,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "bob",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
       end
 
@@ -30,7 +30,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 2,
           metric_name: "active-users",
-          period: "week"
+          period: "week",
         )
       end
     end
@@ -41,14 +41,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 2,
-          success: 1
+          success: 1,
         )
       end
 
@@ -56,7 +56,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
-          period: "week"
+          period: "week",
         )
       end
     end
@@ -67,14 +67,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "bob",
           start: Date.today - 10,
-          success: 1
+          success: 1,
         )
       end
 
@@ -82,7 +82,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
-          period: "week"
+          period: "week",
         )
       end
     end
@@ -93,14 +93,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "bob",
           start: Date.today - 1,
-          success: 0
+          success: 0,
         )
       end
 
@@ -108,7 +108,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
-          period: "week"
+          period: "week",
         )
       end
     end
@@ -119,7 +119,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today,
-          success: 1
+          success: 1,
         )
       end
 
@@ -127,7 +127,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 0,
           metric_name: "active-users",
-          period: "week"
+          period: "week",
         )
       end
     end
@@ -142,14 +142,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 1,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "bob",
           start: Date.today - 26,
-          success: 1
+          success: 1,
         )
       end
 
@@ -157,7 +157,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 2,
           metric_name: "active-users",
-          period: "month"
+          period: "month",
         )
       end
     end
@@ -168,14 +168,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 14,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 20,
-          success: 1
+          success: 1,
         )
       end
 
@@ -183,7 +183,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
-          period: "month"
+          period: "month",
         )
       end
     end
@@ -194,14 +194,14 @@ describe PerformancePlatform::Gateway::ActiveUsers do
           siteIP: "12.12.12.12",
           username: "alice",
           start: Date.today - 33,
-          success: 1
+          success: 1,
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
           username: "bob",
           start: Date.today - 36,
-          success: 1
+          success: 1,
         )
       end
 
@@ -209,7 +209,7 @@ describe PerformancePlatform::Gateway::ActiveUsers do
         expect(result).to eq(
           users: 0,
           metric_name: "active-users",
-          period: "month"
+          period: "month",
         )
       end
     end

--- a/spec/lib/performance_platform/gateway/active_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/active_users_spec.rb
@@ -6,27 +6,27 @@ describe PerformancePlatform::Gateway::ActiveUsers do
     sessions.truncate
   end
 
-  context 'weekly active users' do
-    subject { described_class.new(period: 'week') }
+  context "weekly active users" do
+    subject { described_class.new(period: "week") }
 
-    context 'with users connecting once each in a week' do
+    context "with users connecting once each in a week" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 1,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'bob',
+          username: "bob",
           start: Date.today - 1,
           success: 1
         )
       end
 
-      it 'counts each user' do
+      it "counts each user" do
         expect(result).to eq(
           users: 2,
           metric_name: "active-users",
@@ -35,24 +35,24 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'with users connecting multiple times within a week' do
+    context "with users connecting multiple times within a week" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 1,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 2,
           success: 1
         )
       end
 
-      it 'counts each user only once' do
+      it "counts each user only once" do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
@@ -61,24 +61,24 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'with users connecting outside the current week' do
+    context "with users connecting outside the current week" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 1,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'bob',
+          username: "bob",
           start: Date.today - 10,
           success: 1
         )
       end
 
-      it 'does not count the users outside the week' do
+      it "does not count the users outside the week" do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
@@ -87,24 +87,24 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'with access rejects' do
+    context "with access rejects" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 1,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'bob',
+          username: "bob",
           start: Date.today - 1,
           success: 0
         )
       end
 
-      it 'counts only the successful connections' do
+      it "counts only the successful connections" do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
@@ -113,17 +113,17 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'when the session was today' do
+    context "when the session was today" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today,
           success: 1
         )
       end
 
-      it 'only counts stats from the latest full day' do
+      it "only counts stats from the latest full day" do
         expect(result).to eq(
           users: 0,
           metric_name: "active-users",
@@ -133,27 +133,27 @@ describe PerformancePlatform::Gateway::ActiveUsers do
     end
   end
 
-  context 'monthly active users' do
-    subject { described_class.new(period: 'month') }
+  context "monthly active users" do
+    subject { described_class.new(period: "month") }
 
-    context 'with users connecting once each in a month' do
+    context "with users connecting once each in a month" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 1,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'bob',
+          username: "bob",
           start: Date.today - 26,
           success: 1
         )
       end
 
-      it 'counts each user' do
+      it "counts each user" do
         expect(result).to eq(
           users: 2,
           metric_name: "active-users",
@@ -162,24 +162,24 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'with users connecting multiple times within a month' do
+    context "with users connecting multiple times within a month" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 14,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 20,
           success: 1
         )
       end
 
-      it 'counts each user only once' do
+      it "counts each user only once" do
         expect(result).to eq(
           users: 1,
           metric_name: "active-users",
@@ -188,24 +188,24 @@ describe PerformancePlatform::Gateway::ActiveUsers do
       end
     end
 
-    context 'with users connecting outside the current month' do
+    context "with users connecting outside the current month" do
       before do
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'alice',
+          username: "alice",
           start: Date.today - 33,
           success: 1
         )
 
         sessions.insert(
           siteIP: "12.12.12.12",
-          username: 'bob',
+          username: "bob",
           start: Date.today - 36,
           success: 1
         )
       end
 
-      it 'does not count the users outside the month' do
+      it "does not count the users outside the month" do
         expect(result).to eq(
           users: 0,
           metric_name: "active-users",

--- a/spec/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/lib/performance_platform/gateway/performance_report_spec.rb
@@ -1,18 +1,18 @@
 describe PerformancePlatform::Gateway::PerformanceReport do
-  let(:endpoint) { 'https://performance-platform/' }
-  let(:data) { { metric_name: 'volumetrics', payload: [{ foo: :bar }] } }
+  let(:endpoint) { "https://performance-platform/" }
+  let(:data) { { metric_name: "volumetrics", payload: [{ foo: :bar }] } }
 
   before do
-    ENV['PERFORMANCE_BEARER_VOLUMETRICS'] = 'foobarbaz'
-    ENV['PERFORMANCE_URL'] = endpoint
-    ENV['PERFORMANCE_DATASET'] = 'gov-wifi'
+    ENV["PERFORMANCE_BEARER_VOLUMETRICS"] = "foobarbaz"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = "gov-wifi"
 
     stub_request(:post, "#{endpoint}data/gov-wifi/volumetrics")
     .with(
       body: data[:payload].to_json,
       headers: {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer foobarbaz"
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer foobarbaz"
       }
     )
     .to_return(
@@ -21,22 +21,22 @@ describe PerformancePlatform::Gateway::PerformanceReport do
     )
   end
 
-  context 'with valid data sent' do
-    let(:response) { { status: 'ok' } }
+  context "with valid data sent" do
+    let(:response) { { status: "ok" } }
     let(:response_code) { 200 }
 
-    it 'returns an OK response' do
+    it "returns an OK response" do
       result = subject.send_stats(data)
 
-      expect(result['status']).to eq('ok')
+      expect(result["status"]).to eq("ok")
     end
   end
 
-  context 'with invalid data' do
-    let(:response) { 'error message' }
+  context "with invalid data" do
+    let(:response) { "error message" }
     let(:response_code) { 403 }
 
-    it 'rasises an error' do
+    it "rasises an error" do
       expect { subject.send_stats(data) }.to \
         raise_error(PerformancePlatform::Gateway::HttpError, '403 - "error message"')
     end

--- a/spec/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/lib/performance_platform/gateway/performance_report_spec.rb
@@ -12,7 +12,7 @@ describe PerformancePlatform::Gateway::PerformanceReport do
       body: data[:payload].to_json,
       headers: {
         "Content-Type" => "application/json",
-        "Authorization" => "Bearer foobarbaz"
+        "Authorization" => "Bearer foobarbaz",
       },
     )
     .to_return(

--- a/spec/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/lib/performance_platform/gateway/performance_report_spec.rb
@@ -13,11 +13,11 @@ describe PerformancePlatform::Gateway::PerformanceReport do
       headers: {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer foobarbaz"
-      }
+      },
     )
     .to_return(
       body: response.to_json,
-      status: response_code
+      status: response_code,
     )
   end
 

--- a/spec/lib/performance_platform/gateway/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/roaming_users_spec.rb
@@ -3,10 +3,10 @@ describe PerformancePlatform::Gateway::RoamingUsers do
 
   let(:location_ip_links) { DB[:ip_locations] }
   let(:sessions) { DB[:sessions] }
-  let(:ip_1) { '7.7.7.7' }
-  let(:ip_2) { '8.8.8.8' }
+  let(:ip_1) { "7.7.7.7" }
+  let(:ip_2) { "8.8.8.8" }
   let(:yesterday) { Date.today - 1 }
-  let(:period) { 'week' }
+  let(:period) { "week" }
 
   before do
     sessions.truncate
@@ -16,76 +16,76 @@ describe PerformancePlatform::Gateway::RoamingUsers do
     location_ip_links.insert(ip: ip_2, location_id: 2)
   end
 
-  it 'adds the metric name' do
-    expect(subject.fetch_stats.fetch(:metric_name)).to eq('roaming-users')
+  it "adds the metric name" do
+    expect(subject.fetch_stats.fetch(:metric_name)).to eq("roaming-users")
   end
 
-  context 'weekly' do
-    it 'adds the period to the payload' do
-      expect(subject.fetch_stats.fetch(:period)).to eq('week')
+  context "weekly" do
+    it "adds the period to the payload" do
+      expect(subject.fetch_stats.fetch(:period)).to eq("week")
     end
 
-    context 'given a user has visited more than 1 location' do
-      it 'counts as roaming' do
-        create_session(ip_1, 'alice', yesterday)
-        create_session(ip_2, 'alice', yesterday)
+    context "given a user has visited more than 1 location" do
+      it "counts as roaming" do
+        create_session(ip_1, "alice", yesterday)
+        create_session(ip_2, "alice", yesterday)
 
         expect(subject.fetch_stats.fetch(:roaming)).to eq(1)
         expect(subject.fetch_stats.fetch(:active)).to eq(1)
       end
     end
 
-    context 'given only some users have visited more than 1 location' do
-      it 'counts only those users as roaming' do
-        create_session(ip_1, 'alice', yesterday)
-        create_session(ip_2, 'alice', yesterday)
-        create_session(ip_1, 'sally', yesterday)
-        create_session(ip_1, 'john', yesterday)
+    context "given only some users have visited more than 1 location" do
+      it "counts only those users as roaming" do
+        create_session(ip_1, "alice", yesterday)
+        create_session(ip_2, "alice", yesterday)
+        create_session(ip_1, "sally", yesterday)
+        create_session(ip_1, "john", yesterday)
 
         expect(subject.fetch_stats.fetch(:roaming)).to eq(1)
       end
 
-      context 'given users have only visited one location' do
-        it 'does not count them as roaming' do
-          create_session(ip_1, 'alice', yesterday)
-          create_session(ip_1, 'john', yesterday)
+      context "given users have only visited one location" do
+        it "does not count them as roaming" do
+          create_session(ip_1, "alice", yesterday)
+          create_session(ip_1, "john", yesterday)
 
           expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
         end
       end
     end
 
-    context 'given unsucessful logins' do
-      it 'does not count them as roaming' do
-        create_session(ip_1, 'alice', yesterday, 0)
+    context "given unsucessful logins" do
+      it "does not count them as roaming" do
+        create_session(ip_1, "alice", yesterday, 0)
 
         expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end
     end
   end
 
-  context 'outside the timeframe' do
-    context 'week' do
-      let(:period) { 'week' }
+  context "outside the timeframe" do
+    context "week" do
+      let(:period) { "week" }
 
-      it 'does not count them as roaming' do
-        create_session(ip_1, 'alice', Date.today - 8)
-        create_session(ip_2, 'alice', Date.today - 8)
+      it "does not count them as roaming" do
+        create_session(ip_1, "alice", Date.today - 8)
+        create_session(ip_2, "alice", Date.today - 8)
 
         expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end
     end
 
-    context 'month' do
-      let(:period) { 'month' }
+    context "month" do
+      let(:period) { "month" }
 
-      it 'adds the period to the payload' do
-        expect(subject.fetch_stats.fetch(:period)).to eq('month')
+      it "adds the period to the payload" do
+        expect(subject.fetch_stats.fetch(:period)).to eq("month")
       end
 
-      it 'does not count them as roaming' do
-        create_session(ip_1, 'alice', Date.today - 32)
-        create_session(ip_2, 'alice', Date.today - 32)
+      it "does not count them as roaming" do
+        create_session(ip_1, "alice", Date.today - 32)
+        create_session(ip_2, "alice", Date.today - 32)
 
         expect(subject.fetch_stats.fetch(:roaming)).to eq(0)
       end

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -20,11 +20,11 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
         },
         {
           ip: "186.3.1.1",
-                  location_id: 2,
+          location_id: 2,
         },
         {
           ip: "186.3.4.6",
-                  location_id: 3,
+          location_id: 3,
         },
       ]
     end

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -3,31 +3,31 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
 
   before { subject.save(data) }
 
-  context 'with no data' do
+  context "with no data" do
     let(:data) { [] }
 
-    it 'saves no ip/locations' do
+    it "saves no ip/locations" do
       expect(locations.count).to be_zero
     end
   end
 
-  context 'with three ip/locations' do
+  context "with three ip/locations" do
     let(:data) do
       [
         {
-          ip: '127.0.0.1',
+          ip: "127.0.0.1",
           location_id: 1
         }, {
-          ip: '186.3.1.1',
+          ip: "186.3.1.1",
           location_id: 2
         }, {
-          ip: '186.3.4.6',
+          ip: "186.3.4.6",
           location_id: 3
         }
       ]
     end
 
-    it 'saves those ip/locations' do
+    it "saves those ip/locations" do
       expect(locations.count).to eq(3)
     end
   end

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -17,11 +17,11 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
         {
           ip: "127.0.0.1",
           location_id: 1,
-        }, 
+        },
 {
           ip: "186.3.1.1",
           location_id: 2,
-        }, 
+        },
 {
           ip: "186.3.4.6",
           location_id: 3,

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -18,14 +18,14 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
           ip: "127.0.0.1",
           location_id: 1,
         },
-{
-          ip: "186.3.1.1",
-          location_id: 2,
-        },
-{
-          ip: "186.3.4.6",
-          location_id: 3,
-        },
+        {
+                  ip: "186.3.1.1",
+                  location_id: 2,
+                },
+        {
+                  ip: "186.3.4.6",
+                  location_id: 3,
+                },
       ]
     end
 

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -17,10 +17,12 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
         {
           ip: "127.0.0.1",
           location_id: 1
-        }, {
+        }, 
+{
           ip: "186.3.1.1",
           location_id: 2
-        }, {
+        }, 
+{
           ip: "186.3.4.6",
           location_id: 3
         }

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -19,13 +19,13 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
           location_id: 1,
         },
         {
-                  ip: "186.3.1.1",
+          ip: "186.3.1.1",
                   location_id: 2,
-                },
+        },
         {
-                  ip: "186.3.4.6",
+          ip: "186.3.4.6",
                   location_id: 3,
-                },
+        },
       ]
     end
 

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -16,15 +16,15 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
       [
         {
           ip: "127.0.0.1",
-          location_id: 1
+          location_id: 1,
         }, 
 {
           ip: "186.3.1.1",
-          location_id: 2
+          location_id: 2,
         }, 
 {
           ip: "186.3.4.6",
-          location_id: 3
+          location_id: 3,
         }
       ]
     end

--- a/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/gateway/sequel_ip_locations_spec.rb
@@ -25,7 +25,7 @@ describe PerformancePlatform::Gateway::SequelIPLocations do
 {
           ip: "186.3.4.6",
           location_id: 3,
-        }
+        },
       ]
     end
 

--- a/spec/lib/performance_platform/gateway/unique_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/unique_users_spec.rb
@@ -136,12 +136,12 @@ describe PerformancePlatform::Gateway::UniqueUsers do
       before do
         session_repository.insert(
           username: "xyz123",
-          start: "2018-07-09"
+          start: "2018-07-09",
         )
 
         session_repository.insert(
           username: "abc987",
-          start: "2018-08-09"
+          start: "2018-08-09",
         )
       end
 

--- a/spec/lib/performance_platform/gateway/unique_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/unique_users_spec.rb
@@ -19,137 +19,137 @@ describe PerformancePlatform::Gateway::UniqueUsers do
     Timecop.return
   end
 
-  context 'Given sessions on weekends' do
-    let(:period) { 'week' }
+  context "Given sessions on weekends" do
+    let(:period) { "week" }
 
     before do
-      session_repository.insert(username: 'bob', start: five_days_ago_saturday)
-      session_repository.insert(username: 'alice', start: four_days_ago_sunday)
+      session_repository.insert(username: "bob", start: five_days_ago_saturday)
+      session_repository.insert(username: "alice", start: four_days_ago_sunday)
     end
 
-    it 'assigns the metric name' do
-      expect(subject.fetch_stats.fetch(:metric_name)).to eq('unique-users')
+    it "assigns the metric name" do
+      expect(subject.fetch_stats.fetch(:metric_name)).to eq("unique-users")
     end
 
-    it 'assigns period' do
-      expect(subject.fetch_stats.fetch(:period)).to eq('week')
+    it "assigns period" do
+      expect(subject.fetch_stats.fetch(:period)).to eq("week")
     end
 
-    it 'excludes weekends from the stats' do
+    it "excludes weekends from the stats" do
       expect(subject.fetch_stats.fetch(:count)).to eq(0)
     end
   end
 
-  context 'Given sessions on weekends and weekdays' do
-    let(:period) { 'week' }
+  context "Given sessions on weekends and weekdays" do
+    let(:period) { "week" }
 
     before do
-      session_repository.insert(username: 'bob', start: five_days_ago_saturday)
-      session_repository.insert(username: 'alice', start: six_days_ago_monday)
+      session_repository.insert(username: "bob", start: five_days_ago_saturday)
+      session_repository.insert(username: "alice", start: six_days_ago_monday)
     end
 
-    it 'counts only the weekdays' do
+    it "counts only the weekdays" do
       expect(subject.fetch_stats.fetch(:count)).to eq(1)
     end
   end
 
-  context 'stats for a week' do
-    let(:period) { 'week' }
+  context "stats for a week" do
+    let(:period) { "week" }
 
-    context 'given no sessions' do
-      it 'returns stats with zero unique users' do
+    context "given no sessions" do
+      it "returns stats with zero unique users" do
         expect(subject.fetch_stats.fetch(:count)).to eq(0)
       end
     end
 
-    context 'given many sessions' do
+    context "given many sessions" do
       before do
-        session_repository.insert(username: 'bob', start: today_thursday)
-        session_repository.insert(username: 'alice', start: today_thursday)
-        session_repository.insert(username: 'jon', start: today_thursday)
+        session_repository.insert(username: "bob", start: today_thursday)
+        session_repository.insert(username: "alice", start: today_thursday)
+        session_repository.insert(username: "jon", start: today_thursday)
       end
 
-      it 'returns unique user stats for sessions' do
+      it "returns unique user stats for sessions" do
         expect(subject.fetch_stats).to eq(
           count: 3,
-          metric_name: 'unique-users',
-          period: 'week',
+          metric_name: "unique-users",
+          period: "week",
         )
       end
 
-      it 'averages the statistics' do
-        session_repository.insert(username: 'sam', start: six_days_ago_monday)
-        session_repository.insert(username: 'betty', start: six_days_ago_monday)
+      it "averages the statistics" do
+        session_repository.insert(username: "sam", start: six_days_ago_monday)
+        session_repository.insert(username: "betty", start: six_days_ago_monday)
 
         expect(subject.fetch_stats.fetch(:count)).to eq(2)
       end
 
-      it 'excludes sessions from more than a week ago' do
-        session_repository.insert(username: 'john', start: eight_days_ago_wednesday)
+      it "excludes sessions from more than a week ago" do
+        session_repository.insert(username: "john", start: eight_days_ago_wednesday)
         expect(subject.fetch_stats.fetch(:count)).to eq(3)
       end
     end
   end
 
-  context 'stats for a month' do
-    let(:period) { 'month' }
+  context "stats for a month" do
+    let(:period) { "month" }
 
-    context 'given no sessions' do
-      it 'returns stats with zero unique users' do
+    context "given no sessions" do
+      it "returns stats with zero unique users" do
         expect(subject.fetch_stats).to eq(
           count: 0,
-          metric_name: 'unique-users',
-          period: 'month',
+          metric_name: "unique-users",
+          period: "month",
         )
       end
     end
 
-    context 'many monthly stats' do
+    context "many monthly stats" do
       before do
-        session_repository.insert(username: 'bob', start: six_days_ago_monday)
-        session_repository.insert(username: 'kyle', start: six_days_ago_monday)
-        session_repository.insert(username: 'sally', start: six_days_ago_monday)
+        session_repository.insert(username: "bob", start: six_days_ago_monday)
+        session_repository.insert(username: "kyle", start: six_days_ago_monday)
+        session_repository.insert(username: "sally", start: six_days_ago_monday)
       end
 
-      it 'returns stats for unique users' do
+      it "returns stats for unique users" do
         expect(subject.fetch_stats).to eq(
           count: 3,
-          metric_name: 'unique-users',
-          period: 'month',
+          metric_name: "unique-users",
+          period: "month",
         )
       end
 
-      it 'excludes stats from more than a month ago' do
-        session_repository.insert(username: 'bob', start: thirty_four_days_ago_friday)
+      it "excludes stats from more than a month ago" do
+        session_repository.insert(username: "bob", start: thirty_four_days_ago_friday)
 
         expect(subject.fetch_stats).to eq(
           count: 3,
-          metric_name: 'unique-users',
-          period: 'month',
+          metric_name: "unique-users",
+          period: "month",
         )
       end
     end
 
-    context 'Date override' do
-      subject { described_class.new(period: 'week', date: '2018-07-10') }
+    context "Date override" do
+      subject { described_class.new(period: "week", date: "2018-07-10") }
 
       before do
         session_repository.insert(
-          username: 'xyz123',
-          start: '2018-07-09'
+          username: "xyz123",
+          start: "2018-07-09"
         )
 
         session_repository.insert(
-          username: 'abc987',
-          start: '2018-08-09'
+          username: "abc987",
+          start: "2018-08-09"
         )
       end
 
-      it 'uses the date argument' do
+      it "uses the date argument" do
         expect(subject.fetch_stats).to eq(
           count: 1,
-          metric_name: 'unique-users',
-          period: 'week',
+          metric_name: "unique-users",
+          period: "week",
         )
       end
     end

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -24,7 +24,7 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           dataType: "some-metric-name",
           period: "week",
           type: "active",
-        }, 
+        },
 {
           _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
           _timestamp: "2018-01-31T00:00:00+00:00",

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -27,11 +27,11 @@ describe PerformancePlatform::Presenter::RoamingUsers do
         },
         {
           _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
-                  _timestamp: "2018-01-31T00:00:00+00:00",
-                  count: 100,
-                  dataType: "some-metric-name",
-                  period: "week",
-                  type: "roaming",
+          _timestamp: "2018-01-31T00:00:00+00:00",
+          count: 100,
+          dataType: "some-metric-name",
+          period: "week",
+          type: "roaming",
         },
       ],
     }

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -1,21 +1,21 @@
 describe PerformancePlatform::Presenter::RoamingUsers do
   before do
     Timecop.freeze(Date.new(2018, 2, 1))
-    ENV['PERFORMANCE_DATASET'] = 'some-dataset'
+    ENV["PERFORMANCE_DATASET"] = "some-dataset"
   end
 
   let(:gateway_results) do
     {
-      metric_name: 'some-metric-name',
+      metric_name: "some-metric-name",
       roaming: 100,
       active: 200,
-      period: 'week'
+      period: "week"
     }
   end
 
-  it 'presents the correct data' do
+  it "presents the correct data" do
     expected_result = {
-      metric_name: 'some-metric-name',
+      metric_name: "some-metric-name",
       payload: [
         {
           _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lYWN0aXZl",

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -9,7 +9,7 @@ describe PerformancePlatform::Presenter::RoamingUsers do
       metric_name: "some-metric-name",
       roaming: 100,
       active: 200,
-      period: "week"
+      period: "week",
     }
   end
 
@@ -23,7 +23,7 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           count: 200,
           dataType: "some-metric-name",
           period: "week",
-          type: "active"
+          type: "active",
         }, 
 {
           _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
@@ -31,9 +31,9 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           count: 100,
           dataType: "some-metric-name",
           period: "week",
-          type: "roaming"
+          type: "roaming",
         }
-      ]
+      ],
     }
 
     expect(subject.present(stats: gateway_results)).to eq(expected_result)

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -25,14 +25,14 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           period: "week",
           type: "active",
         },
-{
-          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
-          _timestamp: "2018-01-31T00:00:00+00:00",
-          count: 100,
-          dataType: "some-metric-name",
-          period: "week",
-          type: "roaming",
-        },
+        {
+                  _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
+                  _timestamp: "2018-01-31T00:00:00+00:00",
+                  count: 100,
+                  dataType: "some-metric-name",
+                  period: "week",
+                  type: "roaming",
+                },
       ],
     }
 

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -32,7 +32,7 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           dataType: "some-metric-name",
           period: "week",
           type: "roaming",
-        }
+        },
       ],
     }
 

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -26,13 +26,13 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           type: "active",
         },
         {
-                  _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
+          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
                   _timestamp: "2018-01-31T00:00:00+00:00",
                   count: 100,
                   dataType: "some-metric-name",
                   period: "week",
                   type: "roaming",
-                },
+        },
       ],
     }
 

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -24,7 +24,8 @@ describe PerformancePlatform::Presenter::RoamingUsers do
           dataType: "some-metric-name",
           period: "week",
           type: "active"
-        }, {
+        }, 
+{
           _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
           _timestamp: "2018-01-31T00:00:00+00:00",
           count: 100,

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -42,15 +42,15 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
     let(:bearer_token) { "googoogoo" }
     let(:presenter) { PerformancePlatform::Presenter::ActiveUsers.new }
     let(:stats_gateway) { PerformancePlatform::Gateway::ActiveUsers.new(period: "week") }
-    let(:stats_gateway_response) {
+    let(:stats_gateway_response) do
       {
         users: 3,
         metric_name: "active-users",
         period: "week",
       }
-    }
+    end
 
-    let(:data) {
+    let(:data) do
       {
         metric_name: "active-users",
         payload: [
@@ -64,7 +64,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
           },
         ],
       }
-    }
+    end
 
     it "fetches stats and sends them to Performance service" do
       expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
@@ -79,15 +79,15 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
 
     context "weekly" do
       let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: "week") }
-      let(:stats_gateway_response) {
+      let(:stats_gateway_response) do
         {
           metric_name: "unique-users",
           period: "week",
           count: 5,
         }
-      }
+      end
 
-      let(:data) {
+      let(:data) do
         {
           metric_name: "umnique-users",
           payload: [
@@ -100,7 +100,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
             },
           ],
         }
-      }
+      end
 
       it "fetches stats and sends them to Performance service" do
         expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
@@ -109,15 +109,15 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
 
     context "monthly" do
       let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: "month") }
-      let(:stats_gateway_response) {
+      let(:stats_gateway_response) do
         {
           metric_name: "unique-users",
           period: "month",
           count: 12345,
         }
-      }
+      end
 
-      let(:data) {
+      let(:data) do
         {
           metric_name: "umnique-users",
           payload: [
@@ -130,7 +130,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
             },
           ],
         }
-      }
+      end
 
       it "fetches stats and sends them to Performance service" do
         expect(subject.execute(presenter: presenter)["status"]).to eq("ok")

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -20,11 +20,11 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         headers: {
           "Content-Type" => "application/json",
           "Authorization" => "Bearer #{bearer_token}"
-        }
+        },
       )
       .to_return(
         body: response.to_json,
-        status: 200
+        status: 200,
       )
   end
 
@@ -32,7 +32,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
     described_class.new(
       stats_gateway: stats_gateway,
       performance_gateway: performance_gateway,
-      logger: double(info: "")
+      logger: double(info: ""),
     )
   end
 

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -19,7 +19,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         body: data[:payload].to_json,
         headers: {
           "Content-Type" => "application/json",
-          "Authorization" => "Bearer #{bearer_token}"
+          "Authorization" => "Bearer #{bearer_token}",
         },
       )
       .to_return(
@@ -46,7 +46,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
       {
         users: 3,
         metric_name: "active-users",
-        period: "week"
+        period: "week",
       }
     }
 
@@ -60,9 +60,9 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
             dataType: "active-users",
             period: "week",
             type: "users",
-            count: 3
+            count: 3,
           }
-        ]
+        ],
       }
     }
 
@@ -83,7 +83,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         {
           metric_name: "unique-users",
           period: "week",
-          count: 5
+          count: 5,
         }
       }
 
@@ -96,9 +96,9 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
               _timestamp: "2018-07-16T00:00:00+00:00",
               dataType: "unique-users",
               period: "week",
-              count: 5
+              count: 5,
             }
-          ]
+          ],
         }
       }
 
@@ -113,7 +113,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
         {
           metric_name: "unique-users",
           period: "month",
-          count: 12345
+          count: 12345,
         }
       }
 
@@ -126,9 +126,9 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
               _timestamp: "2018-07-16T00:00:00+00:00",
               dataType: "unique-users",
               period: "month",
-              month_count: 12345
+              month_count: 12345,
             }
-          ]
+          ],
         }
       }
 

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -1,25 +1,25 @@
 describe PerformancePlatform::UseCase::SendPerformanceReport do
   let(:performance_gateway) { PerformancePlatform::Gateway::PerformanceReport.new }
-  let(:endpoint) { 'https://performance-platform/' }
-  let(:response) { { status: 'ok' } }
+  let(:endpoint) { "https://performance-platform/" }
+  let(:response) { { status: "ok" } }
 
   before do
-    allow(presenter).to receive(:generate_timestamp).and_return('2018-07-16T00:00:00+00:00')
+    allow(presenter).to receive(:generate_timestamp).and_return("2018-07-16T00:00:00+00:00")
 
     expect(stats_gateway).to receive(:fetch_stats)
       .and_return(stats_gateway_response)
 
-    ENV['PERFORMANCE_BEARER_ACTIVE_USERS'] = 'googoogoo'
-    ENV['PERFORMANCE_BEARER_UNIQUE_USERS'] = 'boobooboo'
-    ENV['PERFORMANCE_URL'] = endpoint
-    ENV['PERFORMANCE_DATASET'] = dataset
+    ENV["PERFORMANCE_BEARER_ACTIVE_USERS"] = "googoogoo"
+    ENV["PERFORMANCE_BEARER_UNIQUE_USERS"] = "boobooboo"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = dataset
 
     stub_request(:post, "#{endpoint}data/#{dataset}/#{metric}")
       .with(
         body: data[:payload].to_json,
         headers: {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{bearer_token}"
+          "Content-Type" => "application/json",
+          "Authorization" => "Bearer #{bearer_token}"
         }
       )
       .to_return(
@@ -32,108 +32,108 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
     described_class.new(
       stats_gateway: stats_gateway,
       performance_gateway: performance_gateway,
-      logger: double(info: '')
+      logger: double(info: "")
     )
   end
 
-  context 'report for active users' do
-    let(:metric) { 'active-users' }
-    let(:dataset) { 'gov-wifi' }
-    let(:bearer_token) { 'googoogoo' }
+  context "report for active users" do
+    let(:metric) { "active-users" }
+    let(:dataset) { "gov-wifi" }
+    let(:bearer_token) { "googoogoo" }
     let(:presenter) { PerformancePlatform::Presenter::ActiveUsers.new }
-    let(:stats_gateway) { PerformancePlatform::Gateway::ActiveUsers.new(period: 'week') }
+    let(:stats_gateway) { PerformancePlatform::Gateway::ActiveUsers.new(period: "week") }
     let(:stats_gateway_response) {
       {
         users: 3,
-        metric_name: 'active-users',
-        period: 'week'
+        metric_name: "active-users",
+        period: "week"
       }
     }
 
     let(:data) {
       {
-        metric_name: 'active-users',
+        metric_name: "active-users",
         payload: [
           {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3VzZXJz',
-            _timestamp: '2018-07-16T00:00:00+00:00',
-            dataType: 'active-users',
-            period: 'week',
-            type: 'users',
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3VzZXJz",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "active-users",
+            period: "week",
+            type: "users",
             count: 3
           }
         ]
       }
     }
 
-    it 'fetches stats and sends them to Performance service' do
-      expect(subject.execute(presenter: presenter)['status']).to eq('ok')
+    it "fetches stats and sends them to Performance service" do
+      expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
     end
   end
 
-  context 'report for unique users' do
-    let(:metric) { 'unique-users' }
-    let(:dataset) { 'gov-wifi' }
-    let(:bearer_token) { 'boobooboo' }
+  context "report for unique users" do
+    let(:metric) { "unique-users" }
+    let(:dataset) { "gov-wifi" }
+    let(:bearer_token) { "boobooboo" }
     let(:presenter) { PerformancePlatform::Presenter::UniqueUsers.new }
 
-    context 'weekly' do
-      let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: 'week') }
+    context "weekly" do
+      let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: "week") }
       let(:stats_gateway_response) {
         {
-          metric_name: 'unique-users',
-          period: 'week',
+          metric_name: "unique-users",
+          period: "week",
           count: 5
         }
       }
 
       let(:data) {
         {
-          metric_name: 'umnique-users',
+          metric_name: "umnique-users",
           payload: [
             {
-              _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla3VuaXF1ZS11c2Vycw==',
-              _timestamp: '2018-07-16T00:00:00+00:00',
-              dataType: 'unique-users',
-              period: 'week',
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla3VuaXF1ZS11c2Vycw==",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "unique-users",
+              period: "week",
               count: 5
             }
           ]
         }
       }
 
-      it 'fetches stats and sends them to Performance service' do
-        expect(subject.execute(presenter: presenter)['status']).to eq('ok')
+      it "fetches stats and sends them to Performance service" do
+        expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
       end
     end
 
-    context 'monthly' do
-      let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: 'month') }
+    context "monthly" do
+      let(:stats_gateway) { PerformancePlatform::Gateway::UniqueUsers.new(period: "month") }
       let(:stats_gateway_response) {
         {
-          metric_name: 'unique-users',
-          period: 'month',
+          metric_name: "unique-users",
+          period: "month",
           count: 12345
         }
       }
 
       let(:data) {
         {
-          metric_name: 'umnique-users',
+          metric_name: "umnique-users",
           payload: [
             {
-              _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh1bmlxdWUtdXNlcnM=',
-              _timestamp: '2018-07-16T00:00:00+00:00',
-              dataType: 'unique-users',
-              period: 'month',
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh1bmlxdWUtdXNlcnM=",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "unique-users",
+              period: "month",
               month_count: 12345
             }
           ]
         }
       }
 
-      it 'fetches stats and sends them to Performance service' do
-        expect(subject.execute(presenter: presenter)['status']).to eq('ok')
+      it "fetches stats and sends them to Performance service" do
+        expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
       end
     end
   end

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -61,7 +61,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
             period: "week",
             type: "users",
             count: 3,
-          }
+          },
         ],
       }
     }
@@ -97,7 +97,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
               dataType: "unique-users",
               period: "week",
               count: 5,
-            }
+            },
           ],
         }
       }
@@ -127,7 +127,7 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
               dataType: "unique-users",
               period: "month",
               month_count: 12345,
-            }
+            },
           ],
         }
       }

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -2,7 +2,7 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
   subject do
     described_class.new(
       source_gateway: source_gateway,
-      destination_gateway: destination_gateway
+      destination_gateway: destination_gateway,
     )
   end
 

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -15,19 +15,19 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
 
   before { subject.execute }
 
-  it 'fetches from the source gateway' do
+  it "fetches from the source gateway" do
     expect(source_gateway).to have_received(:fetch)
   end
 
-  it 'writes to the destination gateway' do
+  it "writes to the destination gateway" do
     expect(destination_gateway).to have_received(:save)
   end
 
-  context 'given results from the source gateway' do
+  context "given results from the source gateway" do
     let(:results) do
       [
         {
-          ip: '127.0.0.1',
+          ip: "127.0.0.1",
           location_id: 1
         }
       ]
@@ -35,7 +35,7 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
 
     let(:source_gateway) { double(fetch: results) }
 
-    it 'passes results to the destination gateway' do
+    it "passes results to the destination gateway" do
       expect(destination_gateway).to have_received(:save).with(results)
     end
   end

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -28,7 +28,7 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
       [
         {
           ip: "127.0.0.1",
-          location_id: 1
+          location_id: 1,
         }
       ]
     end

--- a/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
+++ b/spec/lib/performance_platform/use_case/synchronize_ip_locations_spec.rb
@@ -29,7 +29,7 @@ describe PerformancePlatform::UseCase::SynchronizeIpLocations do
         {
           ip: "127.0.0.1",
           location_id: 1,
-        }
+        },
       ]
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
-require 'rack/test'
-require 'rspec'
-require 'simplecov'
-require 'sequel'
-require 'webmock/rspec'
-require 'timecop'
+require "rack/test"
+require "rspec"
+require "simplecov"
+require "sequel"
+require "webmock/rspec"
+require "timecop"
 
-ENV['RACK_ENV'] = 'test'
+ENV["RACK_ENV"] = "test"
 
-require File.expand_path '../app.rb', __dir__
+require File.expand_path "../app.rb", __dir__
 
 module RSpecMixin
   include Rack::Test::Methods

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -13,7 +13,7 @@ end
 PERIODS = {
   daily: "day",
   weekly: "week",
-  monthly: "month"
+  monthly: "month",
 }.freeze
 
 PERIODS.each do |adverbial, period|

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -6,7 +6,7 @@ task :synchronize_ip_locations do
   destination_gateway = PerformancePlatform::Gateway::SequelIPLocations.new
   PerformancePlatform::UseCase::SynchronizeIpLocations.new(
     source_gateway: source_gateway,
-    destination_gateway: destination_gateway
+    destination_gateway: destination_gateway,
   ).execute
 end
 
@@ -28,7 +28,7 @@ PERIODS.each do |adverbial, period|
 
     PerformancePlatform::UseCase::SendPerformanceReport.new(
       stats_gateway: active_users_gateway,
-      performance_gateway: performance_gateway
+      performance_gateway: performance_gateway,
     ).execute(presenter: active_users_presenter)
 
     performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
@@ -37,7 +37,7 @@ PERIODS.each do |adverbial, period|
 
     PerformancePlatform::UseCase::SendPerformanceReport.new(
       stats_gateway: roaming_users_gateway,
-      performance_gateway: performance_gateway
+      performance_gateway: performance_gateway,
     ).execute(presenter: roaming_users_presenter)
   end
 end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require "logger"
 logger = Logger.new(STDOUT)
 
 task :synchronize_ip_locations do
@@ -11,9 +11,9 @@ task :synchronize_ip_locations do
 end
 
 PERIODS = {
-  daily: 'day',
-  weekly: 'week',
-  monthly: 'month'
+  daily: "day",
+  weekly: "week",
+  monthly: "month"
 }.freeze
 
 PERIODS.each do |adverbial, period|

--- a/tasks/update_last_login.rb
+++ b/tasks/update_last_login.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 task :update_yesterdays_last_login do
   Gdpr::UseCase::PopulateUserLastLogin.new(

--- a/tasks/update_last_login.rb
+++ b/tasks/update_last_login.rb
@@ -3,6 +3,6 @@ require "date"
 task :update_yesterdays_last_login do
   Gdpr::UseCase::PopulateUserLastLogin.new(
     session_gateway: Gdpr::Gateway::Session.new,
-    last_login_gateway: Gdpr::Gateway::SetLastLogin.new
+    last_login_gateway: Gdpr::Gateway::SetLastLogin.new,
   ).execute(date: Date.today.prev_day)
 end


### PR DESCRIPTION
I've been working on switching from govuk-lint to rubocop-govuk.  We've not updated the linting rules on this repo for a long time, so there will be a lot of violations when we change the linter.

This PR fixes some of those violations in advance.  There are some others that are proving harder to fix.  I hope to sort those out later, but for the moment, let's get these easier changes into master, rather than having them rotting on the long-lived branch that I've cherry-picked them from.

I've batched the changes into separate commits per rule, because otherwise this would be a nightmare to review.