### PR TITLE
fix: put the active users metrics into their own folder

### DIFF
--- a/lib/metrics/active_users.rb
+++ b/lib/metrics/active_users.rb
@@ -30,7 +30,7 @@ module Metrics
     end
 
     def key
-      "active-users-#{period}-#{date}"
+      "active-users/active-users-#{period}-#{date}"
     end
 
     def publish!

--- a/spec/lib/metrics/active_users_spec.rb
+++ b/spec/lib/metrics/active_users_spec.rb
@@ -54,7 +54,7 @@ describe Metrics::ActiveUsers do
   describe "key" do
     it "returns a key for the S3 upload" do
       expect(subject.key)
-        .to eq "active-users-#{subject.period}-#{subject.date}"
+        .to eq "active-users/active-users-#{subject.period}-#{subject.date}"
     end
   end
 


### PR DESCRIPTION
But keep the `active-users` prefix so that downloading a file on its
own (i.e without the folder name) still makes sense.