### PR TITLE
Add the roaming_users data points to the S3 Bucket

### DIFF
--- a/lib/metrics/active_users.rb
+++ b/lib/metrics/active_users.rb
@@ -9,42 +9,29 @@ module Metrics
   class ActiveUsers
     VALID_PERIODS = %w[week day month].freeze
 
-    attr_reader :period, :date, :report, :s3
-
     def initialize(attrs)
       raise ArgumentError unless VALID_PERIODS.include? attrs[:period]
 
       @period = attrs[:period]
       @date = attrs[:date]
-
-      @s3 = Aws::S3::Client.new(region: "eu-west-2")
     end
 
-    def generate!
-      gateway = PerformancePlatform::Gateway::ActiveUsers.new(
-        period: period,
-        date: date,
-      )
-
-      @report = gateway.fetch_stats
+    def execute
+      S3Publisher.publish key, stats
     end
 
     def key
-      "active-users/active-users-#{period}-#{date}"
+      "active-users/active-users-#{@period}-#{@date}"
     end
 
-    def publish!
-      if @report.nil?
-        raise "Nothing to publish; call generate! before publishing."
-      end
+  private
 
-      bucket = ENV.fetch("S3_METRICS_BUCKET")
-
-      @s3.put_object(
-        bucket: bucket,
-        key: key,
-        body: report.to_json.to_s,
+    def stats
+      gateway = PerformancePlatform::Gateway::ActiveUsers.new(
+        period: @period,
+        date: @date,
       )
+      gateway.fetch_stats
     end
   end
 end

--- a/lib/metrics/roaming_users.rb
+++ b/lib/metrics/roaming_users.rb
@@ -1,0 +1,32 @@
+module Metrics
+  class RoamingUsers
+    VALID_PERIODS = %w[week day month].freeze
+
+    def initialize(period:,
+                   date: Date.today.to_s)
+      raise ArgumentError unless VALID_PERIODS.include? period
+
+      @period = period.to_s
+      @date = Date.parse(date)
+    end
+
+    def execute
+      S3Publisher.publish key, stats
+    end
+
+    def key
+      "roaming-users/roaming-users-#{@period}-#{@date}"
+    end
+
+  private
+
+    def stats
+      gateway = PerformancePlatform::Gateway::RoamingUsers.new(
+        period: @period,
+        date: @date.to_s,
+      )
+
+      gateway.fetch_stats
+    end
+  end
+end

--- a/lib/metrics/s3_publisher.rb
+++ b/lib/metrics/s3_publisher.rb
@@ -1,0 +1,13 @@
+module Metrics
+  class S3Publisher
+    def self.publish(key, stats)
+      bucket = ENV.fetch("S3_METRICS_BUCKET")
+
+      Services.s3_client.put_object(
+        bucket: bucket,
+        key: key,
+        body: stats.to_json.to_s,
+      )
+    end
+  end
+end

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -1,19 +1,11 @@
 require "aws-sdk-s3"
 
 class PerformancePlatform::Gateway::S3IpLocations
-  def initialize
-    @s3 = Aws::S3::Client.new(region: "eu-west-2")
-  end
-
   def fetch
     bucket = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_BUCKET")
     key = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY")
 
-    response = s3.get_object(bucket: bucket, key: key)
+    response = Services.s3_client.get_object(bucket: bucket, key: key)
     JSON.parse(response.body.read)
   end
-
-private
-
-  attr_reader :s3
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,5 @@
+class Services
+  def self.s3_client
+    Aws::S3::Client.new(region: "eu-west-2")
+  end
+end

--- a/spec/lib/metrics/roaming_users_spec.rb
+++ b/spec/lib/metrics/roaming_users_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "./s3_fake_client"
+
+describe Metrics::RoamingUsers do
+  let(:today) { Date.today }
+  let(:earlier_today) { Date.today - 0.5 }
+  let(:yesterday) { today - 1 }
+  let(:last_month) { today - 31 }
+  let(:period) { "week" }
+  let(:s3_client) { Metrics.fake_s3_client }
+
+  subject do
+    Metrics::RoamingUsers.new(period: period,
+                              date: today.to_s)
+  end
+
+  before do
+    ENV["S3_METRICS_BUCKET"] = "stub-bucket"
+    DB[:sessions].truncate
+    USER_DB[:userdetails].truncate
+    PerformancePlatform::Gateway::SequelIPLocations.new.save([{ "ip" => "1.2.3.4", "location_id" => 1234 },
+                                                              { "ip" => "2.3.4.5", "location_id" => 2345 }])
+    allow(Services).to receive(:s3_client).and_return s3_client
+  end
+
+  it "rejects invalid periods" do
+    expect { Metrics::RoamingUsers.new(period: "foo", date: Date.today.to_s) }
+      .to raise_error(ArgumentError)
+  end
+
+  describe "#execute" do
+    before do
+      session_params = { "start" => start_date,
+                         "stop" => today,
+                         "siteIP" => "1.2.3.4",
+                         "success" => 1 }
+
+      Session.create(session_params.merge(username: "User1"))
+      Session.create(session_params.merge(username: "User1", "siteIP" => "2.3.4.5"))
+      Session.create(session_params.merge(username: "User2"))
+
+      subject.execute
+
+      result = s3_client.get_object(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: subject.key).body.read
+      parsed_result = JSON.parse(result)
+      @active_users = parsed_result["active"]
+      @roaming_users = parsed_result["roaming"]
+    end
+
+    describe "The start date is yesterday and the period is a week" do
+      let(:start_date) { yesterday }
+      let(:period) { "week" }
+
+      it "uploads 2 active and 1 roaming users to S3" do
+        expect(@active_users).to eq(2)
+        expect(@roaming_users).to eq(1)
+      end
+    end
+
+    describe "The start date is a month ago and the period is a week" do
+      let(:start_date) { last_month }
+      let(:period) { "week" }
+
+      it "uploads 0 active and 0 roaming users to S3" do
+        expect(@active_users).to eq(0)
+        expect(@roaming_users).to eq(0)
+      end
+    end
+
+    describe "The start date is a month ago and the period is a day" do
+      let(:start_date) { last_month }
+      let(:period) { "day" }
+
+      it "uploads 0 active and 0 roaming users to S3" do
+        expect(@active_users).to eq(0)
+        expect(@roaming_users).to eq(0)
+      end
+    end
+
+    describe "The start date is earlier today and the period is a day" do
+      let(:start_date) { today - 0.5 }
+      let(:period) { "day" }
+
+      it "uploads 2 active and 1 roaming users to S3" do
+        expect(@active_users).to eq(2)
+        expect(@roaming_users).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/lib/metrics/s3_fake_client.rb
+++ b/spec/lib/metrics/s3_fake_client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metrics
+  def self.fake_s3_client
+    fake_s3 = {}
+    Aws::S3::Client.new(stub_responses: true).tap do |client|
+      client.stub_responses(
+        :put_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       body = context.params[:body]
+                       fake_s3[bucket] ||= {}
+                       fake_s3[bucket][key] = body
+                       {}
+                     }
+      )
+      client.stub_responses(
+        :get_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       { body: fake_s3.dig(bucket, key) }
+                     }
+      )
+    end
+  end
+end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -50,12 +50,15 @@ PERIODS.each do |adverbial, period|
 
     logger.info("Creating #{adverbial} metrics for S3 with #{args[:date]}")
 
-    metrics = Metrics::ActiveUsers.new(period: period, date: args[:date])
+    metrics_list = [Metrics::ActiveUsers.new(period: period, date: args[:date]),
+                    Metrics::RoamingUsers.new(period: period, date: args[:date])]
 
-    logger.info("[#{metrics.key}] Fetching and uploading metrics...")
+    metrics_list.each do |metrics|
+      logger.info("[#{metrics.key}] Fetching and uploading metrics...")
 
-    metrics.execute
+      metrics.execute
 
-    logger.info("[#{metrics.key}] Done.")
+      logger.info("[#{metrics.key}] Done.")
+    end
   end
 end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -52,13 +52,9 @@ PERIODS.each do |adverbial, period|
 
     metrics = Metrics::ActiveUsers.new(period: period, date: args[:date])
 
-    logger.info("[#{metrics.key}] Generating metrics...")
+    logger.info("[#{metrics.key}] Fetching and uploading metrics...")
 
-    metrics.generate!
-
-    logger.info("[#{metrics.key}] Uploading metrics...")
-
-    metrics.publish!
+    metrics.execute
 
     logger.info("[#{metrics.key}] Done.")
   end


### PR DESCRIPTION
Data points about roaming users that are normally sent to the PP
are now also sent to an S3 bucket.

Trello: https://trello.com/c/lG7cmIzF/408-upload-roamingusers-data-points-to-s3