### PR TITLE
Allow Metrics::IPSynchronizer to be called using a class method

### DIFF
--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -2,7 +2,7 @@ require "logger"
 logger = Logger.new(STDOUT)
 
 task :synchronize_ip_locations do
-  Metrics::IPSynchronizer.execute
+  Metrics::IPSynchronizer.new.execute
 end
 
 PERIODS = {


### PR DESCRIPTION
Fixes a bug in the `synchronize_ip_locations` rake task