### PR TITLE
Revert "Remove rake tasks and code to send stats to the performance platform"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ N.B. The private GovWifi [build repository][build-repo] contains instructions on
 
 - [Overview](#overview)
   - [Sinatra routes](#sinatra-routes)
-  - [Statistics sent over to S3](#statistics-sent-over-to-s3)
+  - [Statistics sent over to the performance platform](#statistics-sent-over-to-the-performance-platform)
     - [Send statistics manually](#send-statistics-manually)
       - [Account Usage](#account-usage)
       - [Unique Users](#unique-users)
@@ -22,7 +22,7 @@ Also known as `post-auth` in FreeRadius terms, this logs to the sessions table w
 
 During the RADIUS `post-auth` action, a POST request is sent to this API containing session data. This API receives this request and saves it to a database.
 
-This application is also responsible for sending statistics to S3.
+This application is also responsible for sending statistics to the Performance Platform.
 
 It stores the following details along with this:
 
@@ -47,7 +47,7 @@ params:
   :authentication_result
 ```
 
-## Statistics sent over to S3
+## Statistics sent over to the performance platform
 
 - Account Usage
 - Unique Users

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -35,9 +35,11 @@ end
 module Common
 end
 
-module Metrics
+module PerformancePlatform
   module Gateway; end
   module Repository; end
+  module UseCase; end
+  module Presenter; end
 end
 
 module Gdpr

--- a/lib/metrics/active_users.rb
+++ b/lib/metrics/active_users.rb
@@ -3,7 +3,7 @@
 module Metrics
   # Utility class to generate and publish a set of metrics for the
   # provided period and date arguments. It delegates the actual
-  # generation to Metrics::Gateway::ActiveUsers and will
+  # generation to PerformancePlatform::Gateway::ActiveUsers and will
   # upload the result in the S3 bucket designated through
   # ENV['S3_METRICS_BUCKET'].
   class ActiveUsers
@@ -27,7 +27,7 @@ module Metrics
   private
 
     def stats
-      gateway = Metrics::Gateway::ActiveUsers.new(
+      gateway = PerformancePlatform::Gateway::ActiveUsers.new(
         period: @period,
         date: @date,
       )

--- a/lib/metrics/roaming_users.rb
+++ b/lib/metrics/roaming_users.rb
@@ -21,7 +21,7 @@ module Metrics
   private
 
     def stats
-      gateway = Metrics::Gateway::RoamingUsers.new(
+      gateway = PerformancePlatform::Gateway::RoamingUsers.new(
         period: @period,
         date: @date.to_s,
       )

--- a/lib/performance_platform/gateway/active_users.rb
+++ b/lib/performance_platform/gateway/active_users.rb
@@ -1,4 +1,4 @@
-class Metrics::Gateway::ActiveUsers
+class PerformancePlatform::Gateway::ActiveUsers
   def initialize(period:, date: Date.today.to_s)
     @period = period
     @date = Date.parse(date)
@@ -17,7 +17,7 @@ class Metrics::Gateway::ActiveUsers
 private
 
   def repository
-    Metrics::Repository::Session
+    PerformancePlatform::Repository::Session
   end
 
   attr_reader :period, :date

--- a/lib/performance_platform/gateway/performance_report.rb
+++ b/lib/performance_platform/gateway/performance_report.rb
@@ -1,0 +1,41 @@
+class PerformancePlatform::Gateway::HttpError < StandardError; end
+
+class PerformancePlatform::Gateway::PerformanceReport
+  def send_stats(data)
+    uri = build_url(data)
+
+    post(uri, data)
+  end
+
+private
+
+  def post(uri, data)
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = build_bearer_token(data)
+    request["Content-Type"] = "application/json"
+    request.body = data[:payload].to_json
+
+    Net::HTTP.start(uri.hostname, 443, use_ssl: true) do |http|
+      response = http.request(request)
+
+      raise PerformancePlatform::Gateway::HttpError, "#{response.code} - #{response.body}" \
+        unless response.code == "200"
+
+      JSON.parse(response.body)
+    end
+  end
+
+  def build_url(data)
+    performance_url = ENV.fetch("PERFORMANCE_URL")
+    dataset_name = ENV.fetch("PERFORMANCE_DATASET")
+    metric_name = data[:metric_name]
+
+    URI("#{performance_url}data/#{dataset_name}/#{metric_name}")
+  end
+
+  def build_bearer_token(data)
+    bearer_const_name = data[:metric_name].tr("-", "_").upcase
+
+    "Bearer #{ENV.fetch('PERFORMANCE_BEARER_' + bearer_const_name)}"
+  end
+end

--- a/lib/performance_platform/gateway/roaming_users.rb
+++ b/lib/performance_platform/gateway/roaming_users.rb
@@ -1,4 +1,4 @@
-class Metrics::Gateway::RoamingUsers
+class PerformancePlatform::Gateway::RoamingUsers
   def initialize(period:, date: Date.today.to_s)
     @period = period.to_s
     @date = Date.parse(date)
@@ -16,7 +16,7 @@ class Metrics::Gateway::RoamingUsers
 private
 
   def repository
-    Metrics::Repository::Session
+    PerformancePlatform::Repository::Session
   end
 
   def active_users_count

--- a/lib/performance_platform/gateway/s3_ip_locations.rb
+++ b/lib/performance_platform/gateway/s3_ip_locations.rb
@@ -1,0 +1,11 @@
+require "aws-sdk-s3"
+
+class PerformancePlatform::Gateway::S3IpLocations
+  def fetch
+    bucket = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_BUCKET")
+    key = ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY")
+
+    response = Services.s3_client.get_object(bucket: bucket, key: key)
+    JSON.parse(response.body.read)
+  end
+end

--- a/lib/performance_platform/presenter/active_users.rb
+++ b/lib/performance_platform/presenter/active_users.rb
@@ -1,0 +1,48 @@
+class PerformancePlatform::Presenter::ActiveUsers
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        as_hash(stats[:users], "users"),
+      ],
+    }
+  end
+
+private
+
+  def generate_timestamp
+    "#{date - 1}T00:00:00+00:00"
+  end
+
+  def as_hash(count, type)
+    {
+      _id: encode_id(type),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      type: type,
+      count: count,
+    }
+  end
+
+  def encode_id(type)
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch("PERFORMANCE_DATASET"),
+        stats[:period],
+        stats[:metric_name],
+        type,
+      ],
+    )
+  end
+
+  attr_reader :stats, :timestamp, :date
+end

--- a/lib/performance_platform/presenter/roaming_users.rb
+++ b/lib/performance_platform/presenter/roaming_users.rb
@@ -1,0 +1,49 @@
+class PerformancePlatform::Presenter::RoamingUsers
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        as_hash(stats[:active], "active"),
+        as_hash(stats[:roaming], "roaming"),
+      ],
+    }
+  end
+
+private
+
+  def as_hash(count, type)
+    {
+      _id: encode_id(type),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      type: type,
+      count: count,
+    }
+  end
+
+  def generate_timestamp
+    "#{date - 1}T00:00:00+00:00"
+  end
+
+  def encode_id(type)
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch("PERFORMANCE_DATASET"),
+        stats[:period],
+        stats[:metric_name],
+        type,
+      ],
+    )
+  end
+
+  attr_reader :stats, :timestamp, :date
+end

--- a/lib/performance_platform/presenter/unique_users.rb
+++ b/lib/performance_platform/presenter/unique_users.rb
@@ -1,0 +1,46 @@
+class PerformancePlatform::Presenter::UniqueUsers
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        {
+          _id: encode_id,
+          _timestamp: timestamp,
+          dataType: stats[:metric_name],
+          period: stats[:period],
+          count_field_name => stats[:count],
+        },
+      ],
+    }
+  end
+
+private
+
+  def generate_timestamp
+    "#{date - 1}T00:00:00+00:00"
+  end
+
+  def encode_id
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch("PERFORMANCE_DATASET"),
+        stats[:period],
+        stats[:metric_name],
+      ],
+    )
+  end
+
+  def count_field_name
+    stats[:period] == "month" ? "month_count" : "count"
+  end
+
+  attr_reader :stats, :timestamp, :date
+end

--- a/lib/performance_platform/repository/session.rb
+++ b/lib/performance_platform/repository/session.rb
@@ -1,4 +1,4 @@
-class Metrics::Repository::Session < Sequel::Model(:sessions)
+class PerformancePlatform::Repository::Session < Sequel::Model(:sessions)
   dataset_module do
     def active_users_stats(period:, date:)
       DB.fetch("

--- a/lib/performance_platform/use_case/send_performance_report.rb
+++ b/lib/performance_platform/use_case/send_performance_report.rb
@@ -1,0 +1,21 @@
+require "logger"
+
+class PerformancePlatform::UseCase::SendPerformanceReport
+  def initialize(stats_gateway:, performance_gateway:, logger: Logger.new(STDOUT))
+    @stats_gateway = stats_gateway
+    @performance_gateway = performance_gateway
+    @logger = logger
+  end
+
+  def execute(presenter:)
+    stats = stats_gateway.fetch_stats
+    performance_data = presenter.present(stats: stats)
+
+    logger.info("Performance data payload: #{performance_data}")
+    performance_gateway.send_stats(performance_data)
+  end
+
+private
+
+  attr_reader :stats_gateway, :performance_gateway, :logger
+end

--- a/spec/lib/performance_platform/gateway/active_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/active_users_spec.rb
@@ -1,4 +1,4 @@
-describe Metrics::Gateway::ActiveUsers do
+describe PerformancePlatform::Gateway::ActiveUsers do
   let(:sessions) { DB[:sessions] }
   let(:result) { subject.fetch_stats }
 

--- a/spec/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/lib/performance_platform/gateway/performance_report_spec.rb
@@ -1,0 +1,44 @@
+describe PerformancePlatform::Gateway::PerformanceReport do
+  let(:endpoint) { "https://performance-platform/" }
+  let(:data) { { metric_name: "volumetrics", payload: [{ foo: :bar }] } }
+
+  before do
+    ENV["PERFORMANCE_BEARER_VOLUMETRICS"] = "foobarbaz"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = "gov-wifi"
+
+    stub_request(:post, "#{endpoint}data/gov-wifi/volumetrics")
+    .with(
+      body: data[:payload].to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer foobarbaz",
+      },
+    )
+    .to_return(
+      body: response.to_json,
+      status: response_code,
+    )
+  end
+
+  context "with valid data sent" do
+    let(:response) { { status: "ok" } }
+    let(:response_code) { 200 }
+
+    it "returns an OK response" do
+      result = subject.send_stats(data)
+
+      expect(result["status"]).to eq("ok")
+    end
+  end
+
+  context "with invalid data" do
+    let(:response) { "error message" }
+    let(:response_code) { 403 }
+
+    it "rasises an error" do
+      expect { subject.send_stats(data) }.to \
+        raise_error(PerformancePlatform::Gateway::HttpError, '403 - "error message"')
+    end
+  end
+end

--- a/spec/lib/performance_platform/gateway/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/gateway/roaming_users_spec.rb
@@ -1,4 +1,4 @@
-describe Metrics::Gateway::RoamingUsers do
+describe PerformancePlatform::Gateway::RoamingUsers do
   subject { described_class.new(period: period) }
 
   let(:location_ip_links) { DB[:ip_locations] }

--- a/spec/lib/performance_platform/presenters/roaming_users_spec.rb
+++ b/spec/lib/performance_platform/presenters/roaming_users_spec.rb
@@ -1,0 +1,41 @@
+describe PerformancePlatform::Presenter::RoamingUsers do
+  before do
+    Timecop.freeze(Date.new(2018, 2, 1))
+    ENV["PERFORMANCE_DATASET"] = "some-dataset"
+  end
+
+  let(:gateway_results) do
+    {
+      metric_name: "some-metric-name",
+      roaming: 100,
+      active: 200,
+      period: "week",
+    }
+  end
+
+  it "presents the correct data" do
+    expected_result = {
+      metric_name: "some-metric-name",
+      payload: [
+        {
+          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lYWN0aXZl",
+          _timestamp: "2018-01-31T00:00:00+00:00",
+          count: 200,
+          dataType: "some-metric-name",
+          period: "week",
+          type: "active",
+        },
+        {
+          _id: "MjAxOC0wMS0zMVQwMDowMDowMCswMDowMHNvbWUtZGF0YXNldHdlZWtzb21lLW1ldHJpYy1uYW1lcm9hbWluZw==",
+          _timestamp: "2018-01-31T00:00:00+00:00",
+          count: 100,
+          dataType: "some-metric-name",
+          period: "week",
+          type: "roaming",
+        },
+      ],
+    }
+
+    expect(subject.present(stats: gateway_results)).to eq(expected_result)
+  end
+end

--- a/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -1,0 +1,73 @@
+describe PerformancePlatform::UseCase::SendPerformanceReport do
+  let(:performance_gateway) { PerformancePlatform::Gateway::PerformanceReport.new }
+  let(:endpoint) { "https://performance-platform/" }
+  let(:response) { { status: "ok" } }
+
+  before do
+    allow(presenter).to receive(:generate_timestamp).and_return("2018-07-16T00:00:00+00:00")
+
+    expect(stats_gateway).to receive(:fetch_stats)
+      .and_return(stats_gateway_response)
+
+    ENV["PERFORMANCE_BEARER_ACTIVE_USERS"] = "googoogoo"
+    ENV["PERFORMANCE_BEARER_UNIQUE_USERS"] = "boobooboo"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = dataset
+
+    stub_request(:post, "#{endpoint}data/#{dataset}/#{metric}")
+      .with(
+        body: data[:payload].to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "Authorization" => "Bearer #{bearer_token}",
+        },
+      )
+      .to_return(
+        body: response.to_json,
+        status: 200,
+      )
+  end
+
+  subject do
+    described_class.new(
+      stats_gateway: stats_gateway,
+      performance_gateway: performance_gateway,
+      logger: double(info: ""),
+    )
+  end
+
+  context "report for active users" do
+    let(:metric) { "active-users" }
+    let(:dataset) { "gov-wifi" }
+    let(:bearer_token) { "googoogoo" }
+    let(:presenter) { PerformancePlatform::Presenter::ActiveUsers.new }
+    let(:stats_gateway) { PerformancePlatform::Gateway::ActiveUsers.new(period: "week") }
+    let(:stats_gateway_response) do
+      {
+        users: 3,
+        metric_name: "active-users",
+        period: "week",
+      }
+    end
+
+    let(:data) do
+      {
+        metric_name: "active-users",
+        payload: [
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2FjdGl2ZS11c2Vyc3VzZXJz",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "active-users",
+            period: "week",
+            type: "users",
+            count: 3,
+          },
+        ],
+      }
+    end
+
+    it "fetches stats and sends them to Performance service" do
+      expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
+    end
+  end
+end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -12,6 +12,32 @@ PERIODS = {
 }.freeze
 
 PERIODS.each do |adverbial, period|
+  name = "publish_#{adverbial}_statistics".to_sym
+
+  task name, [:date] do |_, args|
+    args.with_defaults(date: Date.today.to_s)
+    logger.info("Publishing #{adverbial} statistics with #{args[:date]}")
+    performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
+    active_users_gateway = PerformancePlatform::Gateway::ActiveUsers.new(period: period, date: args[:date])
+    active_users_presenter = PerformancePlatform::Presenter::ActiveUsers.new(date: args[:date])
+
+    PerformancePlatform::UseCase::SendPerformanceReport.new(
+      stats_gateway: active_users_gateway,
+      performance_gateway: performance_gateway,
+    ).execute(presenter: active_users_presenter)
+
+    performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
+    roaming_users_gateway = PerformancePlatform::Gateway::RoamingUsers.new(period: period, date: args[:date])
+    roaming_users_presenter = PerformancePlatform::Presenter::RoamingUsers.new(date: args[:date])
+
+    PerformancePlatform::UseCase::SendPerformanceReport.new(
+      stats_gateway: roaming_users_gateway,
+      performance_gateway: performance_gateway,
+    ).execute(presenter: roaming_users_presenter)
+  end
+end
+
+PERIODS.each do |adverbial, period|
   name = "publish_#{adverbial}_metrics".to_sym
   dependent_tasks = adverbial == :daily ? [:synchronize_ip_locations] : []
 


### PR DESCRIPTION
Reverts alphagov/govwifi-logging-api#333

We're going to remove these rake tasks later as PP retirement is currently put on hold for sometime.