### PR TITLE
Add rake task to sync S3 volumetrics with ElasticSearch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 ruby File.read(".ruby-version").chomp
 
 gem "aws-sdk-s3", "~> 1"
+gem "elasticsearch"
 gem "mysql2"
 gem "puma"
 gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,14 @@ GEM
     crack (0.4.4)
     diff-lcs (1.4.4)
     docile (1.3.2)
+    elasticsearch (7.12.0)
+      elasticsearch-api (= 7.12.0)
+      elasticsearch-transport (= 7.12.0)
+    elasticsearch-api (7.12.0)
+      multi_json
+    elasticsearch-transport (7.12.0)
+      faraday (~> 1)
+      multi_json
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -171,6 +179,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
+  elasticsearch
   guard-rspec
   mysql2
   puma

--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,5 @@ require "./lib/loader"
 
 require "./tasks/publish_statistics"
 require "./tasks/session_deletion"
+require "./tasks/sync_s3_volumetrics"
 require "./tasks/update_last_login"

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -47,4 +47,8 @@ module Gdpr
   module UseCase; end
 end
 
+module Volumetrics
+  module UseCase; end
+end
+
 require_all "lib"

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -48,6 +48,7 @@ module Gdpr
 end
 
 module Volumetrics
+  module Gateway; end
   module UseCase; end
 end
 

--- a/lib/volumetrics/gateway/elasticsearch.rb
+++ b/lib/volumetrics/gateway/elasticsearch.rb
@@ -2,7 +2,6 @@ require "elasticsearch"
 
 class Volumetrics::Gateway::Elasticsearch
   def write(key, data)
-
     client = Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
 
     client.index(

--- a/lib/volumetrics/gateway/elasticsearch.rb
+++ b/lib/volumetrics/gateway/elasticsearch.rb
@@ -1,0 +1,15 @@
+require "elasticsearch"
+
+class Volumetrics::Gateway::Elasticsearch
+  def write(key, data)
+
+    client = Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
+
+    client.index(
+      index: "volumetrics",
+      type: "object",
+      id: key,
+      body: data,
+    )
+  end
+end

--- a/lib/volumetrics/gateway/s3.rb
+++ b/lib/volumetrics/gateway/s3.rb
@@ -6,7 +6,7 @@ class Volumetrics::Gateway::S3
   def each(&block)
     keys.each do |key|
       json = Services.s3_client.get_object(bucket: bucket, key: key)
-      block.call({ key: key[PREFIX.length..-1], body: JSON.parse(json.body.read) })
+      block.call(key[PREFIX.length..-1], JSON.parse(json.body.read))
     end
   end
 

--- a/lib/volumetrics/gateway/s3.rb
+++ b/lib/volumetrics/gateway/s3.rb
@@ -15,7 +15,7 @@ private
   end
 
   def list_objects(continuation_token = nil)
-    response = Services.s3_client.list_objects_v2({ bucket: bucket, continuation_token: continuation_token })
+    response = Services.s3_client.list_objects_v2({ bucket: bucket, prefix: "volumetrics/", continuation_token: continuation_token })
     objects = response.data.contents
 
     if response.data.is_truncated

--- a/lib/volumetrics/gateway/s3.rb
+++ b/lib/volumetrics/gateway/s3.rb
@@ -1,0 +1,31 @@
+class Volumetrics::Gateway::S3
+  include Enumerable
+
+  def each(&block)
+    keys.each do |key|
+      json = Services.s3_client.get_object(bucket: bucket, key: key)
+      block.call({ key: key, body: JSON.parse(json.body.read) })
+    end
+  end
+
+private
+
+  def keys
+    list_objects.map(&:key)
+  end
+
+  def list_objects(continuation_token = nil)
+    response = Services.s3_client.list_objects_v2({ bucket: bucket, continuation_token: continuation_token })
+    objects = response.data.contents
+
+    if response.data.is_truncated
+      objects += list_objects(response.data.next_continuation_token)
+    end
+
+    objects
+  end
+
+  def bucket
+    ENV.fetch("S3_METRICS_BUCKET")
+  end
+end

--- a/lib/volumetrics/gateway/s3.rb
+++ b/lib/volumetrics/gateway/s3.rb
@@ -1,10 +1,12 @@
 class Volumetrics::Gateway::S3
   include Enumerable
 
+  PREFIX = "volumetrics/".freeze
+
   def each(&block)
     keys.each do |key|
       json = Services.s3_client.get_object(bucket: bucket, key: key)
-      block.call({ key: key, body: JSON.parse(json.body.read) })
+      block.call({ key: key[PREFIX.length..-1], body: JSON.parse(json.body.read) })
     end
   end
 
@@ -15,7 +17,7 @@ private
   end
 
   def list_objects(continuation_token = nil)
-    response = Services.s3_client.list_objects_v2({ bucket: bucket, prefix: "volumetrics/", continuation_token: continuation_token })
+    response = Services.s3_client.list_objects_v2({ bucket: bucket, prefix: PREFIX, continuation_token: continuation_token })
     objects = response.data.contents
 
     if response.data.is_truncated

--- a/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
+++ b/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
@@ -10,8 +10,8 @@ class Volumetrics::UseCase::SyncS3ToElasticsearch
   def execute
     record_count = 0
 
-    @s3_gateway.each do |record|
-      @elasticsearch_gateway.write(record[:key], record[:data])
+    @s3_gateway.each do |key, data|
+      @elasticsearch_gateway.write(key, data)
       record_count += 1
     end
 

--- a/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
+++ b/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
@@ -8,12 +8,13 @@ class Volumetrics::UseCase::SyncS3ToElasticsearch
   end
 
   def execute
-    records = @s3_gateway.fetch
+    record_count = 0
 
-    @logger.info "Writing #{records.count} records from S3 to ElasticSearch"
-
-    records.each do |record|
-      @elasticsearch_gateway.write(record[:filename], record[:data])
+    @s3_gateway.each do |record|
+      @elasticsearch_gateway.write(record[:key], record[:data])
+      record_count += 1
     end
+
+    @logger.info "Writing #{record_count} records from S3 to ElasticSearch"
   end
 end

--- a/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
+++ b/lib/volumetrics/use_case/sync_s3_to_elasticsearch.rb
@@ -1,0 +1,19 @@
+require "logger"
+
+class Volumetrics::UseCase::SyncS3ToElasticsearch
+  def initialize(s3_gateway:, elasticsearch_gateway:, logger: Logger.new(STDOUT))
+    @s3_gateway = s3_gateway
+    @elasticsearch_gateway = elasticsearch_gateway
+    @logger = logger
+  end
+
+  def execute
+    records = @s3_gateway.fetch
+
+    @logger.info "Writing #{records.count} records from S3 to ElasticSearch"
+
+    records.each do |record|
+      @elasticsearch_gateway.write(record[:filename], record[:data])
+    end
+  end
+end

--- a/spec/lib/metrics/s3_fake_client.rb
+++ b/spec/lib/metrics/s3_fake_client.rb
@@ -21,6 +21,21 @@ module Metrics
                        { body: fake_s3.dig(bucket, key) }
                      }
       )
+      client.stub_responses(
+        :list_objects_v2,
+        lambda { |context|
+          bucket = context.params[:bucket]
+          continuation_token = context.params[:continuation_token]
+
+          continuation_token && {
+            contents: fake_s3[bucket].keys[1000..1999].map { |key| { key: key } },
+          } || {
+            contents: fake_s3[bucket].keys[0..999].map { |key| { key: key } },
+            is_truncated: true,
+            next_continuation_token: "foo",
+          }
+        },
+      )
     end
   end
 end

--- a/spec/lib/metrics/s3_fake_client.rb
+++ b/spec/lib/metrics/s3_fake_client.rb
@@ -26,11 +26,16 @@ module Metrics
         lambda { |context|
           bucket = context.params[:bucket]
           continuation_token = context.params[:continuation_token]
+          prefix = context.params[:prefix]
+
+          keys = fake_s3[bucket].keys
+                                .select { |k| !prefix || k.slice(0, prefix.length) == prefix }
+                                .map { |key| { key: key } }
 
           continuation_token && {
-            contents: fake_s3[bucket].keys[1000..1999].map { |key| { key: key } },
+            contents: keys[1000..1999],
           } || {
-            contents: fake_s3[bucket].keys[0..999].map { |key| { key: key } },
+            contents: keys[0..999],
             is_truncated: true,
             next_continuation_token: "foo",
           }

--- a/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
@@ -1,4 +1,4 @@
-describe Volumetrics::Gateway::Elasticsearch, :focus do
+describe Volumetrics::Gateway::Elasticsearch do
   let(:elasticsearch_client) { double(index: nil) }
   let(:url) { "http://#{ENV['VOLUMETRICS_ENDPOINT']}:9200/volumetrics/object/bar" }
 

--- a/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
@@ -1,0 +1,20 @@
+describe Volumetrics::Gateway::Elasticsearch, :focus do
+  let(:elasticsearch_client) { double(index: nil) }
+  let(:url) { "http://#{ENV['VOLUMETRICS_ENDPOINT']}:9200/volumetrics/object/bar" }
+
+  before do
+    ENV["VOLUMETRICS_ENDPOINT"] = "foo"
+
+    stub_request(:put, url).with(
+      body: { foo: "bar" }.to_json,
+    ).to_return(status: 200)
+  end
+
+  it "calls ElasticSearch API with expected args" do
+    subject.write("bar", { foo: "bar" })
+
+    assert_requested :put, url,
+                     body: { foo: "bar" }.to_json,
+                     times: 1
+  end
+end

--- a/spec/lib/volumetrics/gateway/s3_spec.rb
+++ b/spec/lib/volumetrics/gateway/s3_spec.rb
@@ -21,10 +21,10 @@ describe Volumetrics::Gateway::S3 do
   end
 
   it "has expected first object" do
-    expect(subject.to_a.first).to eq({ key: "foo-0", body: { "bar" => "baz-0" } })
+    expect(subject.to_a.first).to eq([ "foo-0", { "bar" => "baz-0" } ])
   end
 
   it "has expected last object" do
-    expect(subject.to_a.last).to eq({ key: "foo-1499", body: { "bar" => "baz-1499" } })
+    expect(subject.to_a.last).to eq([ "foo-1499", { "bar" => "baz-1499" } ])
   end
 end

--- a/spec/lib/volumetrics/gateway/s3_spec.rb
+++ b/spec/lib/volumetrics/gateway/s3_spec.rb
@@ -1,0 +1,30 @@
+require_relative "../../metrics/s3_fake_client"
+
+describe Volumetrics::Gateway::S3 do
+  let(:s3_client) { Metrics.fake_s3_client }
+
+  before do
+    ENV["S3_METRICS_BUCKET"] = "stub-bucket"
+    allow(Services).to receive(:s3_client).and_return s3_client
+
+    100.times do |t|
+      s3_client.put_object({ bucket: "stub_bucket", key: "foo/bar-#{t}" })
+    end
+
+    1500.times do |t|
+      s3_client.put_object({ bucket: "stub-bucket", key: "volumetrics/foo-#{t}", body: { bar: "baz-#{t}" }.to_json })
+    end
+  end
+
+  it "has expected number of objects" do
+    expect(subject.count).to eq(1500)
+  end
+
+  it "has expected first object" do
+    expect(subject.to_a.first).to eq({ key: "volumetrics/foo-0", body: { "bar" => "baz-0" } })
+  end
+
+  it "has expected last object" do
+    expect(subject.to_a.last).to eq({ key: "volumetrics/foo-1499", body: { "bar" => "baz-1499" } })
+  end
+end

--- a/spec/lib/volumetrics/gateway/s3_spec.rb
+++ b/spec/lib/volumetrics/gateway/s3_spec.rb
@@ -21,10 +21,10 @@ describe Volumetrics::Gateway::S3 do
   end
 
   it "has expected first object" do
-    expect(subject.to_a.first).to eq({ key: "volumetrics/foo-0", body: { "bar" => "baz-0" } })
+    expect(subject.to_a.first).to eq({ key: "foo-0", body: { "bar" => "baz-0" } })
   end
 
   it "has expected last object" do
-    expect(subject.to_a.last).to eq({ key: "volumetrics/foo-1499", body: { "bar" => "baz-1499" } })
+    expect(subject.to_a.last).to eq({ key: "foo-1499", body: { "bar" => "baz-1499" } })
   end
 end

--- a/spec/lib/volumetrics/gateway/s3_spec.rb
+++ b/spec/lib/volumetrics/gateway/s3_spec.rb
@@ -21,10 +21,10 @@ describe Volumetrics::Gateway::S3 do
   end
 
   it "has expected first object" do
-    expect(subject.to_a.first).to eq([ "foo-0", { "bar" => "baz-0" } ])
+    expect(subject.to_a.first).to eq(["foo-0", { "bar" => "baz-0" }])
   end
 
   it "has expected last object" do
-    expect(subject.to_a.last).to eq([ "foo-1499", { "bar" => "baz-1499" } ])
+    expect(subject.to_a.last).to eq(["foo-1499", { "bar" => "baz-1499" }])
   end
 end

--- a/spec/lib/volumetrics/gateway/s3_spec.rb
+++ b/spec/lib/volumetrics/gateway/s3_spec.rb
@@ -8,7 +8,7 @@ describe Volumetrics::Gateway::S3 do
     allow(Services).to receive(:s3_client).and_return s3_client
 
     100.times do |t|
-      s3_client.put_object({ bucket: "stub_bucket", key: "foo/bar-#{t}" })
+      s3_client.put_object({ bucket: "stub-bucket", key: "foo/bar-#{t}", body: { foo: "bar-#{t}" }.to_json })
     end
 
     1500.times do |t|

--- a/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
@@ -10,7 +10,7 @@ describe Volumetrics::UseCase::SyncS3ToElasticsearch do
   let(:elasticsearch_gateway) { double(write: nil) }
 
   before do
-    allow(s3_gateway).to receive(:each).and_yield({ key: "baz", data: {} }).and_return %w[baz]
+    allow(s3_gateway).to receive(:each).and_yield("baz", {}).and_return %w[baz]
   end
 
   context "Given s3 and elasticsearch gateways" do
@@ -18,7 +18,7 @@ describe Volumetrics::UseCase::SyncS3ToElasticsearch do
       subject.execute
     end
 
-    it "calls fetch on the s3 gateway" do
+    it "calls each on the s3 gateway" do
       expect(s3_gateway).to have_received(:each)
     end
 

--- a/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
@@ -1,0 +1,30 @@
+describe Volumetrics::UseCase::SyncS3ToElasticsearch do
+  subject do
+    described_class.new(
+      s3_gateway: s3_gateway,
+      elasticsearch_gateway: elasticsearch_gateway,
+    )
+  end
+
+  let(:s3_gateway) {
+    double(fetch: [
+      { filename: "baz", data: {} },
+    ])
+  }
+
+  let(:elasticsearch_gateway) { double(write: nil) }
+
+  context "Given s3 and elasticsearch gateways" do
+    before(:each) do
+      subject.execute
+    end
+
+    it "calls fetch on the s3 gateway" do
+      expect(s3_gateway).to have_received(:fetch)
+    end
+
+    it "calls write on the elasticsearch gateway with expected args" do
+      expect(elasticsearch_gateway).to have_received(:write).with("baz", {})
+    end
+  end
+end

--- a/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/use_case/sync_s3_to_elasticsearch_spec.rb
@@ -6,13 +6,12 @@ describe Volumetrics::UseCase::SyncS3ToElasticsearch do
     )
   end
 
-  let(:s3_gateway) {
-    double(fetch: [
-      { filename: "baz", data: {} },
-    ])
-  }
-
+  let(:s3_gateway) { double }
   let(:elasticsearch_gateway) { double(write: nil) }
+
+  before do
+    allow(s3_gateway).to receive(:each).and_yield({ key: "baz", data: {} }).and_return %w[baz]
+  end
 
   context "Given s3 and elasticsearch gateways" do
     before(:each) do
@@ -20,7 +19,7 @@ describe Volumetrics::UseCase::SyncS3ToElasticsearch do
     end
 
     it "calls fetch on the s3 gateway" do
-      expect(s3_gateway).to have_received(:fetch)
+      expect(s3_gateway).to have_received(:each)
     end
 
     it "calls write on the elasticsearch gateway with expected args" do

--- a/tasks/sync_s3_volumetric.rb
+++ b/tasks/sync_s3_volumetric.rb
@@ -1,0 +1,6 @@
+task :sync_s3_volumetrics do
+  PerformancePlatform::UseCase::SyncS3ToElasticSearch.new(
+   elastic_search_gateway: PerformancePlatform::Gateway::ElasticSearch.new,
+   s3_gateway: PerformancePlatform::Gateway::S3.new
+  ).execute
+end

--- a/tasks/sync_s3_volumetric.rb
+++ b/tasks/sync_s3_volumetric.rb
@@ -1,6 +1,0 @@
-task :sync_s3_volumetrics do
-  PerformancePlatform::UseCase::SyncS3ToElasticSearch.new(
-   elastic_search_gateway: PerformancePlatform::Gateway::ElasticSearch.new,
-   s3_gateway: PerformancePlatform::Gateway::S3.new
-  ).execute
-end

--- a/tasks/sync_s3_volumetrics.rb
+++ b/tasks/sync_s3_volumetrics.rb
@@ -1,0 +1,6 @@
+task :sync_s3_volumetrics do
+  Volumetrics::UseCase::SyncS3ToElasticsearch.new(
+   elasticsearch_gateway: Volumetrics::Gateway::Elasticsearch.new,
+   s3_gateway: Volumetrics::Gateway::S3.new
+  ).execute
+end

--- a/tasks/sync_s3_volumetrics.rb
+++ b/tasks/sync_s3_volumetrics.rb
@@ -1,6 +1,6 @@
 task :sync_s3_volumetrics do
   Volumetrics::UseCase::SyncS3ToElasticsearch.new(
-   elasticsearch_gateway: Volumetrics::Gateway::Elasticsearch.new,
-   s3_gateway: Volumetrics::Gateway::S3.new
+    elasticsearch_gateway: Volumetrics::Gateway::Elasticsearch.new,
+    s3_gateway: Volumetrics::Gateway::S3.new,
   ).execute
 end


### PR DESCRIPTION
## What

Add a rake task to read volumetric objects in S3, and write them to the ElasticSearch volumetrics index.

## Why

When we install ES we need to populate it with historical performance data. We also need a disaster recovery mechanism to restore performance data from a backup.

https://trello.com/c/4sQz7DZm