### PR TITLE
Send a Volumetrics data point to Elasticsearch

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -49,6 +49,7 @@ end
 
 module Volumetrics
   module Gateway; end
+  module Repository; end
   module UseCase; end
 end
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,4 +2,8 @@ class Services
   def self.s3_client
     Aws::S3::Client.new(region: "eu-west-2")
   end
+
+  def self.elasticsearch_client
+    Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
+  end
 end

--- a/lib/volumetrics/gateway/elasticsearch.rb
+++ b/lib/volumetrics/gateway/elasticsearch.rb
@@ -6,8 +6,6 @@ class Volumetrics::Gateway::Elasticsearch
 
     client.index(
       index: "volumetrics",
-      type: "object",
-      id: key,
       body: data,
     )
   end

--- a/lib/volumetrics/gateway/elasticsearch.rb
+++ b/lib/volumetrics/gateway/elasticsearch.rb
@@ -1,8 +1,8 @@
 require "elasticsearch"
 
 class Volumetrics::Gateway::Elasticsearch
-  def write(key, data)
-    client = Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
+  def write(data)
+    client = Services.elasticsearch_client
 
     client.index(
       index: "volumetrics",

--- a/lib/volumetrics/repository/sign_up.rb
+++ b/lib/volumetrics/repository/sign_up.rb
@@ -1,0 +1,40 @@
+class Volumetrics::Repository::SignUp < Sequel::Model(USER_DB[:userdetails])
+  dataset_module do
+    def all(date)
+      where(Sequel.lit("date(created_at) <= '#{date - 1}'"))
+    end
+
+    def day_before(date)
+      where(Sequel.lit("date(created_at) = '#{date - 1}'"))
+    end
+
+    def self_sign
+      where(contact: Sequel[:sponsor])
+    end
+
+    def sponsored
+      exclude(contact: Sequel[:sponsor])
+    end
+
+    def with_sms
+      where(Sequel.like(:contact, "+%"))
+    end
+
+    def with_email
+      where(Sequel.like(:contact, "%@%"))
+    end
+
+    def week_before(date)
+      where(Sequel.lit("date(created_at) BETWEEN '#{date - 14}' AND '#{date - 7}'"))
+    end
+
+    def month_before(date)
+      yesterday = date.prev_day
+      where(Sequel.lit("date(created_at) BETWEEN '#{yesterday.prev_month}' AND '#{yesterday}'"))
+    end
+
+    def with_successful_login
+      exclude(last_login: nil)
+    end
+  end
+end

--- a/lib/volumetrics/use_case/fetch_data.rb
+++ b/lib/volumetrics/use_case/fetch_data.rb
@@ -1,0 +1,63 @@
+class Volumetrics::UseCase::FetchData
+  attr_reader :period
+
+  def initialize(date: Date.today.to_s, period: "day")
+    @date = Date.parse(date)
+    @period = period
+  end
+
+  def fetch
+    {
+      period: period,
+      metric_name: "volumetrics",
+      period_before: signups_period_before.count,
+      cumulative: signups_cumulative.count,
+      sms_period_before: sms_signups_period_before.count,
+      sms_cumulative: sms_signups_cumulative.count,
+      email_period_before: email_signups_period_before.count,
+      email_cumulative: email_signups_cumulative.count,
+      sponsored_period_before: sponsored_signups_period_before.count,
+      sponsored_cumulative: sponsored_signups_cumulative.count,
+    }
+  end
+
+private
+
+  attr_reader :date
+
+  def repository
+    Volumetrics::Repository::SignUp
+  end
+
+  def signups_period_before
+    repository.send("#{period}_before", date)
+  end
+
+  def signups_cumulative
+    repository.all(date)
+  end
+
+  def sms_signups_period_before
+    signups_period_before.self_sign.with_sms
+  end
+
+  def sms_signups_cumulative
+    signups_cumulative.self_sign.with_sms
+  end
+
+  def email_signups_period_before
+    signups_period_before.self_sign.with_email
+  end
+
+  def email_signups_cumulative
+    signups_cumulative.self_sign.with_email
+  end
+
+  def sponsored_signups_cumulative
+    signups_cumulative.sponsored
+  end
+
+  def sponsored_signups_period_before
+    signups_period_before.sponsored
+  end
+end

--- a/lib/volumetrics/use_case/send_to_elasticsearch.rb
+++ b/lib/volumetrics/use_case/send_to_elasticsearch.rb
@@ -1,0 +1,17 @@
+class Volumetrics::UseCase::SendToElasticsearch
+  def initialize(
+    elasticsearch_gateway: Volumetrics::Gateway::Elasticsearch,
+    logger: Logger.new(STDOUT),
+    data_fetcher: Volumetrics::UseCase::FetchData
+  )
+    @elasticsearch_gateway = elasticsearch_gateway
+    @logger = logger
+    @data_fetcher = data_fetcher.new
+  end
+
+  def execute
+    data = @data_fetcher.fetch
+    @elasticsearch_gateway.new.write data
+    @logger.info "Wrote volumetrics data point '#{data}' to Elasticsearch"
+  end
+end

--- a/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/gateway/elasticsearch_spec.rb
@@ -1,19 +1,19 @@
 describe Volumetrics::Gateway::Elasticsearch do
   let(:elasticsearch_client) { double(index: nil) }
-  let(:url) { "http://#{ENV['VOLUMETRICS_ENDPOINT']}:9200/volumetrics/object/bar" }
+  let(:url) { "http://#{ENV['VOLUMETRICS_ENDPOINT']}:9200/volumetrics/_doc" }
 
   before do
     ENV["VOLUMETRICS_ENDPOINT"] = "foo"
 
-    stub_request(:put, url).with(
+    stub_request(:post, url).with(
       body: { foo: "bar" }.to_json,
     ).to_return(status: 200)
   end
 
   it "calls ElasticSearch API with expected args" do
-    subject.write("bar", { foo: "bar" })
+    subject.write(foo: "bar")
 
-    assert_requested :put, url,
+    assert_requested :post, url,
                      body: { foo: "bar" }.to_json,
                      times: 1
   end

--- a/spec/lib/volumetrics/use_case/fetch_data_spec.rb
+++ b/spec/lib/volumetrics/use_case/fetch_data_spec.rb
@@ -1,0 +1,270 @@
+describe Volumetrics::UseCase::FetchData do
+  let(:user_repository) { Class.new(Volumetrics::Repository::SignUp) { unrestrict_primary_key } }
+
+  before do
+    USER_DB[:userdetails].truncate
+  end
+
+  context "given no signups" do
+    it "returns stats with zero signups" do
+      expect(subject.fetch).to eq(
+        period_before: 0,
+        cumulative: 0,
+        sms_period_before: 0,
+        sms_cumulative: 0,
+        metric_name: "volumetrics",
+        period: "day",
+        email_period_before: 0,
+        email_cumulative: 0,
+        sponsored_cumulative: 0,
+        sponsored_period_before: 0,
+      )
+    end
+  end
+
+  context "with user sign up date being a full timestamp" do
+    before do
+      user_repository.create(username: "full", created_at: Time.at(Time.now.to_i - 86_400))
+    end
+
+    it "compares sign up creation date by date only" do
+      expect(subject.fetch[:period_before]).to eq(1)
+    end
+  end
+
+  context "given 3 signups yesterday" do
+    before do
+      3.times do |i|
+        user_repository.create(username: "new #{i}", created_at: Date.today - 1)
+      end
+    end
+
+    it "returns signups for yesterday" do
+      expect(subject.fetch[:period_before]).to eq(3)
+    end
+
+    it "returns same cumulative number of signups" do
+      expect(subject.fetch[:cumulative]).to eq(3)
+    end
+  end
+
+  context "given 5 signups yesterday and 1 day before that" do
+    before do
+      user_repository.create(username: "old", created_at: Date.today - 2)
+
+      5.times do |i|
+        user_repository.create(username: "new #{i}", created_at: Date.today - 1)
+      end
+    end
+
+    it "returns zero signups 5 signups for yesterday" do
+      expect(subject.fetch[:period_before]).to eq(5)
+    end
+
+    it "returns zero signups 6 signups cumulative" do
+      expect(subject.fetch[:cumulative]).to eq(6)
+    end
+  end
+
+  context "given 2 signups today" do
+    before do
+      2.times do |i|
+        user_repository.create(username: i, created_at: Date.today)
+      end
+    end
+
+    it "returns zero signups for yesterday" do
+      expect(subject.fetch[:period_before]).to eq(0)
+    end
+
+    it "returns zero signups cumulative" do
+      expect(subject.fetch[:cumulative]).to eq(0)
+    end
+  end
+
+  context "given 1 SMS signup yesterday and 2 email signups" do
+    before do
+      user_repository.create(
+        username: "Email 1",
+        contact: "foo@bar.com",
+        sponsor: "foo@bar.com",
+        created_at: Date.today - 1,
+      )
+
+      user_repository.create(
+        username: "Email 2",
+        contact: "foo@baz.com",
+        sponsor: "foo@baz.com",
+        created_at: Date.today - 1,
+      )
+
+      user_repository.create(
+        username: "SMS",
+        contact: "+0123456789",
+        sponsor: "+0123456789",
+        created_at: Date.today - 1,
+      )
+    end
+
+    it "counts all of them against cumulative singups" do
+      expect(subject.fetch[:cumulative]).to eq(3)
+    end
+
+    it "counts all of them against yesterdays signups" do
+      expect(subject.fetch[:period_before]).to eq(3)
+    end
+
+    it "calculates SMS cumulative signups" do
+      expect(subject.fetch[:sms_cumulative]).to eq(1)
+    end
+
+    it "calculates SMS yesterdays signups" do
+      expect(subject.fetch[:sms_period_before]).to eq(1)
+    end
+
+    it "calculates email cumulative signups" do
+      expect(subject.fetch[:email_cumulative]).to eq(2)
+    end
+
+    it "calculates email yesterdays signups" do
+      expect(subject.fetch[:email_period_before]).to eq(2)
+    end
+  end
+
+  context "given SMS signups made on different dates" do
+    before do
+      user_repository.create(
+        username: "SMS old",
+        created_at: Date.today - 6,
+        contact: "+1123456789",
+        sponsor: "+1123456789",
+      )
+
+      user_repository.create(
+        username: "SMS new",
+        contact: "+0123456789",
+        sponsor: "+0123456789",
+        created_at: Date.today - 1,
+      )
+    end
+
+    it "counts them against cumulative singups" do
+      expect(subject.fetch[:cumulative]).to eq(2)
+    end
+
+    it "counts them against yesterdays signups" do
+      expect(subject.fetch[:period_before]).to eq(1)
+    end
+
+    it "counts them against SMS cumulative signups" do
+      expect(subject.fetch[:sms_cumulative]).to eq(2)
+    end
+
+    it "counts them against SMS yesterdays signups" do
+      expect(subject.fetch[:sms_period_before]).to eq(1)
+    end
+  end
+
+  context "given email signups made on different dates" do
+    before do
+      user_repository.create(
+        username: "Email old",
+        created_at: Date.today - 5,
+        contact: "foo@bar.com",
+        sponsor: "foo@bar.com",
+      )
+
+      user_repository.create(
+        username: "Email new",
+        contact: "foo@baz.com",
+        sponsor: "foo@baz.com",
+        created_at: Date.today - 1,
+      )
+    end
+
+    it "counts them against cumulative singups" do
+      expect(subject.fetch[:cumulative]).to eq(2)
+    end
+
+    it "counts them against yesterdays signups" do
+      expect(subject.fetch[:period_before]).to eq(1)
+    end
+
+    it "counts them against email cumulative signups" do
+      expect(subject.fetch[:email_cumulative]).to eq(2)
+    end
+
+    it "counts them against email signups yesterday" do
+      expect(subject.fetch[:email_period_before]).to eq(1)
+    end
+  end
+
+  context "given sponsored sign ups" do
+    before do
+      user_repository.create(
+        username: "Email",
+        contact: "foo@bar.com",
+        sponsor: "sponsor@bar.com",
+        created_at: Date.today - 1,
+      )
+
+      user_repository.create(
+        username: "SMS",
+        contact: "foo@baz.com",
+        sponsor: "sponsor@baz.com",
+        created_at: Date.today - 2,
+      )
+    end
+
+    it "counts both of them to cumulative number of sponsored sign ups" do
+      expect(subject.fetch[:sponsored_cumulative]).to eq(2)
+    end
+
+    it "counts one of them as sponsored sign up yesterday" do
+      expect(subject.fetch[:sponsored_period_before]).to eq(1)
+    end
+  end
+
+  context "Date override" do
+    subject { described_class.new(date: "2018-08-10") }
+
+    before do
+      user_repository.create(
+        username: "Email",
+        contact: "foo@bar.com",
+        sponsor: "sponsor@bar.com",
+        created_at: "2018-08-09",
+      )
+
+      user_repository.create(
+        username: "SMS",
+        contact: "foo@baz.com",
+        sponsor: "sponsor@baz.com",
+        created_at: "2018-08-29",
+      )
+    end
+
+    it "counts both of them to cumulative number of sponsored sign ups" do
+      expect(subject.fetch[:sponsored_cumulative]).to eq(1)
+    end
+
+    it "counts one of them as sponsored sign up yesterday" do
+      expect(subject.fetch[:sponsored_period_before]).to eq(1)
+    end
+  end
+
+  context "Stats for month" do
+    subject { described_class.new(period: "month") }
+
+    before do
+      yesterday = Date.today.prev_day
+      user_repository.create(username: "Email", contact: "foo@bar.com", created_at: yesterday.prev_month)
+      user_repository.create(username: "SMS", contact: "1234567", created_at: yesterday.prev_day)
+      user_repository.create(username: "Notme", contact: "2345678", created_at: yesterday.prev_month.prev_day)
+    end
+
+    it "counts signups for the previous month" do
+      expect(subject.fetch[:period_before]).to eq(2)
+    end
+  end
+end

--- a/spec/lib/volumetrics/use_case/send_to_elasticsearch_spec.rb
+++ b/spec/lib/volumetrics/use_case/send_to_elasticsearch_spec.rb
@@ -1,0 +1,32 @@
+describe Volumetrics::UseCase::SendToElasticsearch do
+  before do
+    USER_DB[:userdetails].truncate
+  end
+
+  let(:user_repository) { Class.new(Volumetrics::Repository::SignUp) { unrestrict_primary_key } }
+  let(:elasticsearch_client) { spy }
+
+  context "given a signup" do
+    before do
+      user_repository.create(username: "full", created_at: Date.today - 1)
+      allow(Services).to receive(:elasticsearch_client).and_return elasticsearch_client
+    end
+    it "gets a data point from the database and writes it to elasticsearch" do
+      expected_hash = {
+        period_before: 1,
+        cumulative: 1,
+        sms_period_before: 0,
+        sms_cumulative: 0,
+        metric_name: "volumetrics",
+        period: "day",
+        email_period_before: 0,
+        email_cumulative: 0,
+        sponsored_cumulative: 0,
+        sponsored_period_before: 0,
+      }
+      Volumetrics::UseCase::SendToElasticsearch.new.execute
+      expect(elasticsearch_client).to have_received(:index).with({ index: "volumetrics",
+                                                                   body: expected_hash })
+    end
+  end
+end

--- a/tasks/publish_metrics_to_elasticsearch.rb
+++ b/tasks/publish_metrics_to_elasticsearch.rb
@@ -1,0 +1,3 @@
+task :publish_metrics_to_elasticsearch do
+  Volumetrics::UseCase::SendToElasticsearch.new.execute
+end


### PR DESCRIPTION
Adds a rake task to send a volumetrics data point to Elasticsearch.

Previously such tasks were located in the User signup api. We are moving them all to the logging api so that
there is one place where all metrics code is, which makes code sharing and finding code easier.

Trello: https://trello.com/c/RH2Q1Fk6/1027-3-update-rake-tasks-to-upload-data-points-to-elastic-search