### PR TITLE
Fix publish_metricst_to_elasticsearch rake task

### DIFF
--- a/tasks/publish_metrics_to_elasticsearch.rb
+++ b/tasks/publish_metrics_to_elasticsearch.rb
@@ -1,3 +1,12 @@
+require "logger"
+logger = Logger.new(STDOUT)
+
+PERIODS = {
+  daily: "day",
+  weekly: "week",
+  monthly: "month",
+}.freeze
+
 PERIODS.each do |adverbial, period|
   name = "publish_#{adverbial}_metrics_to_elasticsearch".to_sym
 


### PR DESCRIPTION
Add missing PERIODS constant and logger definition.