### PR TITLE
Correct S3 bucket names

### DIFF
--- a/tasks/sync_s3_volumetrics.rb
+++ b/tasks/sync_s3_volumetrics.rb
@@ -6,12 +6,12 @@ task :sync_s3_volumetrics do
 
   Performance::UseCase::SyncS3ToElasticsearch.new(
     elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("active_users"),
-    s3_gateway: Performance::Gateway::S3.new("active-users"),
+    s3_gateway: Performance::Gateway::S3.new("active_users"),
   ).execute
 
   Performance::UseCase::SyncS3ToElasticsearch.new(
     elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("roaming_users"),
-    s3_gateway: Performance::Gateway::S3.new("roaming-users"),
+    s3_gateway: Performance::Gateway::S3.new("roaming_users"),
   ).execute
 
   Performance::UseCase::SyncS3ToElasticsearch.new(


### PR DESCRIPTION
## What

Fix S3 bucket names

## Why

Because the old ones aren't correct.