### PR TITLE
Fixes in metrics rake tasks

### DIFF
--- a/tasks/publish_metrics_to_elasticsearch.rb
+++ b/tasks/publish_metrics_to_elasticsearch.rb
@@ -1,13 +1,7 @@
 require "logger"
 logger = Logger.new(STDOUT)
 
-PERIODS = {
-  daily: "day",
-  weekly: "week",
-  monthly: "month",
-}.freeze
-
-PERIODS.each do |adverbial, period|
+Performance::Metrics::MetricSender::VALID_PERIODS.each do |adverbial, period|
   name = "publish_#{adverbial}_metrics_to_elasticsearch".to_sym
 
   task name, [:date] do |_, args|
@@ -17,7 +11,7 @@ PERIODS.each do |adverbial, period|
 
     metrics_list = %i[active_users completion_rate roaming_users volumetrics]
     metrics_list.each do |metrics|
-      metric_sender = Metrics::MetricSender.new(period: period, date: args[:date], metric: metrics)
+      metric_sender = Performance::Metrics::MetricSender.new(period: period, date: args[:date], metric: metrics)
 
       logger.info("[#{metric_sender.key}] Fetching and uploading metrics...")
 

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -5,13 +5,7 @@ task :synchronize_ip_locations do
   Performance::Metrics::IPSynchronizer.new.execute
 end
 
-PERIODS = {
-  daily: "day",
-  weekly: "week",
-  monthly: "month",
-}.freeze
-
-PERIODS.each do |adverbial, period|
+Performance::Metrics::MetricSender::VALID_PERIODS.each do |adverbial, period|
   name = "publish_#{adverbial}_metrics".to_sym
   dependent_tasks = adverbial == :daily ? [:synchronize_ip_locations] : []
 


### PR DESCRIPTION
- The MetricSender needs to include all module names
- The PERIODS constant was redefined. Use the one from the MetricSender