### PR TITLE
All metrics now use one index in Elasticsearch

### DIFF
--- a/lib/performance/metrics.rb
+++ b/lib/performance/metrics.rb
@@ -1,0 +1,3 @@
+module Performance::Metrics
+  ELASTICSEARCH_INDEX = "GovWifi-metrics".freeze
+end

--- a/lib/performance/metrics/metric_sender.rb
+++ b/lib/performance/metrics/metric_sender.rb
@@ -34,7 +34,7 @@ module Performance::Metrics
     end
 
     def to_elasticsearch
-      Performance::Gateway::Elasticsearch.new(@metric.to_s).write(key, stats)
+      Performance::Gateway::Elasticsearch.new(ELASTICSEARCH_INDEX).write(key, stats)
     end
 
     def key

--- a/spec/lib/performance/metrics/metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/metric_sender_spec.rb
@@ -123,22 +123,22 @@ describe Performance::Metrics::MetricSender do
     it "indexes active users data into Elasticsearch" do
       active_users.to_elasticsearch
       expect(elasticsearch_client).to have_received(:index)
-        .with({ index: "active_users", id: "active_users-week-#{today}", body: active_users_expected_hash.symbolize_keys })
+        .with({ index: Performance::Metrics::ELASTICSEARCH_INDEX, id: "active_users-week-#{today}", body: active_users_expected_hash.symbolize_keys })
     end
     it "indexes completion rate data into Elasticsearch" do
       completion_rate.to_elasticsearch
       expect(elasticsearch_client).to have_received(:index)
-        .with({ index: "completion_rate", id: "completion_rate-week-#{today}", body: completion_rate_expected_hash.symbolize_keys })
+        .with({ index: Performance::Metrics::ELASTICSEARCH_INDEX, id: "completion_rate-week-#{today}", body: completion_rate_expected_hash.symbolize_keys })
     end
     it "indexes roaming users into Elasticsearch" do
       roaming_users.to_elasticsearch
       expect(elasticsearch_client).to have_received(:index)
-        .with({ index: "roaming_users", id: "roaming_users-week-#{today}", body: roaming_users_expected_hash.symbolize_keys })
+        .with({ index: Performance::Metrics::ELASTICSEARCH_INDEX, id: "roaming_users-week-#{today}", body: roaming_users_expected_hash.symbolize_keys })
     end
     it "indexes volumetrics data into Elasticsearch" do
       volumetrics.to_elasticsearch
       expect(elasticsearch_client).to have_received(:index)
-        .with({ index: "volumetrics", id: "volumetrics-week-#{today}", body: volumetrics_expected_hash.symbolize_keys })
+        .with({ index: Performance::Metrics::ELASTICSEARCH_INDEX, id: "volumetrics-week-#{today}", body: volumetrics_expected_hash.symbolize_keys })
     end
   end
 end

--- a/tasks/sync_s3_volumetrics.rb
+++ b/tasks/sync_s3_volumetrics.rb
@@ -1,21 +1,21 @@
 task :sync_s3_volumetrics do
   Performance::UseCase::SyncS3ToElasticsearch.new(
-    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("volumetrics"),
+    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new(Performance::Metrics::ELASTICSEARCH_INDEX),
     s3_gateway: Performance::Gateway::S3.new("volumetrics"),
   ).execute
 
   Performance::UseCase::SyncS3ToElasticsearch.new(
-    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("active_users"),
+    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new(Performance::Metrics::ELASTICSEARCH_INDEX),
     s3_gateway: Performance::Gateway::S3.new("active_users"),
   ).execute
 
   Performance::UseCase::SyncS3ToElasticsearch.new(
-    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("roaming_users"),
+    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new(Performance::Metrics::ELASTICSEARCH_INDEX),
     s3_gateway: Performance::Gateway::S3.new("roaming_users"),
   ).execute
 
   Performance::UseCase::SyncS3ToElasticsearch.new(
-    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new("completion_rate"),
+    elasticsearch_gateway: Performance::Gateway::Elasticsearch.new(Performance::Metrics::ELASTICSEARCH_INDEX),
     s3_gateway: Performance::Gateway::S3.new("completion_rate"),
   ).execute
 end


### PR DESCRIPTION
### What
All performance metrics now use one index in ElasticSearch

### Why
We can easily differentiate between metrics using the 'metric_name'
attribute and using one index allows us to show multiple metrics
in one dashboard in Grafana

Link to Trello card (if applicable): https://trello.com/c/ThQ5YdQB/1297-story-3-the-volume-of-unique-users-who-use-the-service-on-a-monthly-basis
