### PR TITLE
Elasticsearch indices should be lowercase

### DIFF
--- a/lib/performance/metrics.rb
+++ b/lib/performance/metrics.rb
@@ -1,3 +1,3 @@
 module Performance::Metrics
-  ELASTICSEARCH_INDEX = "GovWifi-metrics".freeze
+  ELASTICSEARCH_INDEX = "govwifi-metrics".freeze
 end


### PR DESCRIPTION
### What
Elasticsearch indices should be lowercase
### Why
Otherwise an exception is thrown
