### PR TITLE
Add task_id to session logging.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-18T15:29:48Z",
+  "generated_at": "2021-07-29T14:36:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
       {
         "hashed_secret": "4b8616475fc852dfd8ba8138b7667e67ad52fb63",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 135,
         "type": "Hex High Entropy String"
       }
     ],

--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -44,6 +44,7 @@ module Logging
         siteIP: @params.fetch("site_ip_address"),
         building_identifier: building_identifier(@params.fetch("called_station_id")),
         success: access_accept?,
+        task_id: @params.fetch("task_id"),
       }
     end
 

--- a/mysql/migrations/20210727141200_add_task_id_to_sessions.rb
+++ b/mysql/migrations/20210727141200_add_task_id_to_sessions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :sessions do
+      add_column :task_id, String, default: "", size: 100
+    end
+  end
+end

--- a/spec/features/certs_logging_spec.rb
+++ b/spec/features/certs_logging_spec.rb
@@ -14,6 +14,7 @@ describe App do
           called_station_id: nil,
           site_ip_address: nil,
           authentication_result: authentication_result,
+          task_id: "arn:aws:ecs:task_id",
         }.to_json
       end
       let(:post_auth_request) { post "/logging/post-auth", request_body }
@@ -57,6 +58,7 @@ describe App do
         called_station_id: nil,
         site_ip_address: nil,
         authentication_result: authentication_result,
+        task_id: "arn:aws:ecs:task_id",
       }.to_json
     end
     let(:post_auth_request) { post "/logging/post-auth", request_body }

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -10,6 +10,7 @@ describe App do
     let(:called_station_id) { "01-39-38-25-2A-80" }
     let(:site_ip_address) { "93.11.238.187" }
     let(:cert_name) { "" }
+    let(:task_id) { "arn:aws:ecs:task_id" }
     let(:request_body) do
       {
         username: username,
@@ -18,6 +19,7 @@ describe App do
         called_station_id: called_station_id,
         site_ip_address: site_ip_address,
         authentication_result: authentication_result,
+        task_id: task_id,
       }.to_json
     end
     let(:post_auth_request) { post "/logging/post-auth", request_body }
@@ -60,6 +62,7 @@ describe App do
           expect(session.mac).to eq(mac)
           expect(session.ap).to eq(called_station_id)
           expect(session.siteIP).to eq(site_ip_address)
+          expect(session.task_id).to eq(task_id)
         end
 
         context 'Given the "Called Station ID" is an MAC address' do


### PR DESCRIPTION
The task_id parameter has recently been added to the Radius rest
plugin's post-auth hook.

This PR enables this parameter to be stored.

### Why
We want to be able to surface this in the admin portal

https://trello.com/c/htMbaqCQ/1469-show-which-radius-server-was-used-to-serve-a-request-in-the-admin-portal2

see also: https://github.com/alphagov/govwifi-frontend/pull/143