### PR TITLE
Move database migration step to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ RUN apk --no-cache add --virtual .build-deps build-base && \
 
 COPY . .
 
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
 CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "8080"]

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ serve: build
 	$(DOCKER_COMPOSE) up -d user_db
 	./mysql_user/bin/wait_for_mysql
 	$(DOCKER_COMPOSE) up -d app
-	$(DOCKER_COMPOSE) run --rm app bundle exec rake db:migrate
 
 lint: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec rubocop

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+bundle exec rake db:migrate
+exec "$@"


### PR DESCRIPTION
The database migration should run everytime the docker
container starts and before the application runs.

### Why
The acceptance frontend tests won't run properly because it does not use the Makefile
which means the migrations don't run
