### PR TITLE
Add migration to add reply message to session table. Add reply messag…

### DIFF
--- a/lib/logging/post_auth.rb
+++ b/lib/logging/post_auth.rb
@@ -45,6 +45,7 @@ module Logging
         building_identifier: building_identifier(@params.fetch("called_station_id")),
         success: access_accept?,
         task_id: @params.fetch("task_id"),
+        authentication_reply: @params.fetch("authentication_reply"),
       }
     end
 

--- a/mysql/migrations/20210810122800_add_reply_message_to_sessions.rb
+++ b/mysql/migrations/20210810122800_add_reply_message_to_sessions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :sessions do
+      add_column :authentication_reply, String, default: ""
+    end
+  end
+end

--- a/spec/features/certs_logging_spec.rb
+++ b/spec/features/certs_logging_spec.rb
@@ -15,11 +15,13 @@ describe App do
           site_ip_address: nil,
           authentication_result: authentication_result,
           task_id: "arn:aws:ecs:task_id",
+          authentication_reply: authentication_reply,
         }.to_json
       end
       let(:post_auth_request) { post "/logging/post-auth", request_body }
       let(:cert_name) { "Example Certificate Common Name" }
       let(:authentication_result) { "Access-Accept" }
+      let(:authentication_reply) { "This is a reply message" }
 
       before { post_auth_request }
 
@@ -49,7 +51,7 @@ describe App do
     let(:username) { "ABCDE" }
     let(:mac) { "DA-59-19-8B-39-2D" }
     let(:authentication_result) { "Access-Accept" }
-
+    let(:authentication_reply) { "This is a reply message" }
     let(:request_body) do
       {
         username: username,
@@ -59,6 +61,7 @@ describe App do
         site_ip_address: nil,
         authentication_result: authentication_result,
         task_id: "arn:aws:ecs:task_id",
+        authentication_reply: authentication_reply,
       }.to_json
     end
     let(:post_auth_request) { post "/logging/post-auth", request_body }

--- a/spec/features/post_auth_spec.rb
+++ b/spec/features/post_auth_spec.rb
@@ -11,6 +11,7 @@ describe App do
     let(:site_ip_address) { "93.11.238.187" }
     let(:cert_name) { "" }
     let(:task_id) { "arn:aws:ecs:task_id" }
+    let(:authentication_reply) { "This is a reply message" }
     let(:request_body) do
       {
         username: username,
@@ -20,6 +21,7 @@ describe App do
         site_ip_address: site_ip_address,
         authentication_result: authentication_result,
         task_id: task_id,
+        authentication_reply: authentication_reply,
       }.to_json
     end
     let(:post_auth_request) { post "/logging/post-auth", request_body }
@@ -63,6 +65,7 @@ describe App do
           expect(session.ap).to eq(called_station_id)
           expect(session.siteIP).to eq(site_ip_address)
           expect(session.task_id).to eq(task_id)
+          expect(session.authentication_reply).to eq(authentication_reply)
         end
 
         context 'Given the "Called Station ID" is an MAC address' do


### PR DESCRIPTION
Add migration to add reply message to session table. Add reply message to data stored by post auth.

### What

Any authentication reply from RADIUS is stored in the logging database.

### Why

There was an anomaly whereby this part of the POST request was sent but not stored.


Link to Trello card (if applicable): 

https://trello.com/c/CgDBlYW1/1385-add-radius-reply-message-to-the-sessions-table-1