### PR TITLE
Add a Rake task to send a list of IP addresses and the number of failed and successful requests to Elasticsearch.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ end
 require "./tasks/migrate"
 require "./tasks/publish_metrics_to_elasticsearch"
 require "./tasks/publish_statistics"
+require "./tasks/send_request_statistics"
 require "./tasks/session_deletion"
 require "./tasks/sync_s3_volumetrics"
 require "./tasks/update_last_login"

--- a/lib/performance/gateway/elasticsearch.rb
+++ b/lib/performance/gateway/elasticsearch.rb
@@ -14,4 +14,12 @@ class Performance::Gateway::Elasticsearch
       body: data,
     )
   end
+
+  def bulk_write(data_array)
+    client = Services.elasticsearch_client
+    client.bulk(
+      index: @index,
+      body: data_array,
+    )
+  end
 end

--- a/lib/performance/metrics/request_stats_sender.rb
+++ b/lib/performance/metrics/request_stats_sender.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Performance::Metrics
+  class RequestStatsSender
+    SESSION_INDEX = "session"
+
+    def initialize(date_time: Time.now)
+      @date_time = date_time
+    end
+
+    def send_data
+      Performance::Gateway::Elasticsearch.new(SESSION_INDEX).bulk_write(stats) unless stats.empty?
+    end
+
+  private
+
+    def stats
+      Performance::Repository::Session.request_stats(date_time: @date_time).to_a
+    end
+  end
+end

--- a/lib/performance/repository/session.rb
+++ b/lib/performance/repository/session.rb
@@ -1,5 +1,17 @@
 class Performance::Repository::Session < Sequel::Model(:sessions)
   dataset_module do
+    def request_stats(date_time:)
+      sql_time = date_time.strftime("%Y-%m-%d %H:%M:%S")
+      sql = "SELECT
+               '#{sql_time}' AS time,
+               siteIP,
+               COUNT(CASE WHEN success='1' THEN 1 end) AS Successes,
+               COUNT(CASE WHEN success='0' THEN 1 end) AS Failures
+             FROM sessions WHERE start BETWEEN date_sub('#{sql_time}', INTERVAL 1 HOUR) AND '#{sql_time}'
+             GROUP BY siteIP"
+      DB.fetch(sql).to_a
+    end
+
     def active_users_stats(period:, date:)
       DB.fetch("
         SELECT

--- a/spec/lib/performance/metrics/request_stats_sender_spec.rb
+++ b/spec/lib/performance/metrics/request_stats_sender_spec.rb
@@ -1,0 +1,51 @@
+describe Performance::Metrics::RequestStatsSender do
+  let(:elasticsearch_client) { spy }
+  let(:sessions) { DB[:sessions] }
+  let(:ip1) { "12.12.12.12" }
+  let(:ip2) { "20.20.20.20" }
+  let(:ip3) { "20.30.40.50" }
+  let(:time_string) { "2021-08-18 15:18:08" }
+  let(:time) { Time.parse(time_string) }
+
+  before :each do
+    allow(Services).to receive(:elasticsearch_client).and_return elasticsearch_client
+    sessions.truncate
+  end
+  it "Sends nothing" do
+    Performance::Metrics::RequestStatsSender.new(date_time: time).send_data
+    expect(elasticsearch_client).to_not have_received(:bulk)
+  end
+  it "Sends the number of successful and failed requests in the last hour to elasticsearch" do
+    sessions.insert(
+      siteIP: ip1,
+      start: time,
+      success: "1",
+    )
+    sessions.insert(
+      siteIP: ip1,
+      start: time - 60,
+      success: "1",
+    )
+    sessions.insert(
+      siteIP: ip1,
+      start: time - 60,
+      success: "0",
+    )
+    sessions.insert(
+      siteIP: ip2,
+      start: time - 60,
+      success: "1",
+    )
+    sessions.insert(
+      siteIP: ip2,
+      username: "elis",
+      start: time - 60 * 60 * 2,
+      success: "1",
+    )
+
+    Performance::Metrics::RequestStatsSender.new(date_time: time).send_data
+    expect(elasticsearch_client).to have_received(:bulk).with(index: Performance::Metrics::RequestStatsSender::SESSION_INDEX,
+                                                              body: match_array([{ time: time_string, Failures: 1, Successes: 2, siteIP: "12.12.12.12" },
+                                                                                 { time: time_string, Failures: 0, Successes: 1, siteIP: "20.20.20.20" }]))
+  end
+end

--- a/tasks/send_request_statistics.rb
+++ b/tasks/send_request_statistics.rb
@@ -1,0 +1,6 @@
+require "logger"
+require "./lib/performance/metrics"
+
+task :send_request_statistics do
+  Performance::Metrics::RequestStatsSender.new.send_data
+end


### PR DESCRIPTION
### What
Add a Rake task to send a list of IP addresses and the number of failed and successful requests each to Elasticsearch.

### Why
We want to be able to visualise the number of failed and successful requests per IP address in Grafana

Link to Trello card (if applicable): 
https://trello.com/c/iuIWfaxw/1502-super-admin-time-series-of-org-traffic-3
