### PR TITLE
Make send_request_statistics rake task load the environment

### DIFF
--- a/tasks/send_request_statistics.rb
+++ b/tasks/send_request_statistics.rb
@@ -1,6 +1,5 @@
 require "logger"
-require "./lib/performance/metrics"
 
-task :send_request_statistics do
+task send_request_statistics: :load_env do
   Performance::Metrics::RequestStatsSender.new.send_data
 end


### PR DESCRIPTION
### What
Make send_request_statistics rake task load the environment

### Why
Otherwise it can't find any of the classes it depends on
