### PR TITLE
Fix the bulk upload code.

### DIFF
--- a/lib/performance/gateway/elasticsearch.rb
+++ b/lib/performance/gateway/elasticsearch.rb
@@ -19,7 +19,7 @@ class Performance::Gateway::Elasticsearch
     client = Services.elasticsearch_client
     client.bulk(
       index: @index,
-      body: data_array,
+      body: data_array.map { |data| { index: { data: data } } },
     )
   end
 end

--- a/spec/lib/performance/metrics/request_stats_sender_spec.rb
+++ b/spec/lib/performance/metrics/request_stats_sender_spec.rb
@@ -45,7 +45,27 @@ describe Performance::Metrics::RequestStatsSender do
 
     Performance::Metrics::RequestStatsSender.new(date_time: time).send_data
     expect(elasticsearch_client).to have_received(:bulk).with(index: Performance::Metrics::RequestStatsSender::SESSION_INDEX,
-                                                              body: match_array([{ time: time_string, Failures: 1, Successes: 2, siteIP: "12.12.12.12" },
-                                                                                 { time: time_string, Failures: 0, Successes: 1, siteIP: "20.20.20.20" }]))
+                                                              body: [
+                                                                {
+                                                                  index: {
+                                                                    data: {
+                                                                      time: time_string,
+                                                                      Failures: 1,
+                                                                      Successes: 2,
+                                                                      siteIP: "12.12.12.12",
+                                                                    },
+                                                                  },
+                                                                },
+                                                                {
+                                                                  index: {
+                                                                    data: {
+                                                                      time: time_string,
+                                                                      Failures: 0,
+                                                                      Successes: 1,
+                                                                      siteIP: "20.20.20.20",
+                                                                    },
+                                                                  },
+                                                                },
+                                                              ])
   end
 end


### PR DESCRIPTION
### What
Elasticsearch requires a very specific array to be sent as part of
a bulk indexing operation. This commit implements that correctly.

### Why
Otherwise Elasticsearch will reject the bulk upload.