### PR TITLE
Format the timestamp in a way that Elasticsearch understands

### DIFF
--- a/lib/performance/repository/session.rb
+++ b/lib/performance/repository/session.rb
@@ -2,8 +2,9 @@ class Performance::Repository::Session < Sequel::Model(:sessions)
   dataset_module do
     def request_stats(date_time:)
       sql_time = date_time.strftime("%Y-%m-%d %H:%M:%S")
+      elasticsearch_time = date_time.strftime("%Y-%m-%dT%H:%M:%S")
       sql = "SELECT
-               '#{sql_time}' AS time,
+               '#{elasticsearch_time}' AS time,
                siteIP,
                COUNT(CASE WHEN success='1' THEN 1 end) AS Successes,
                COUNT(CASE WHEN success='0' THEN 1 end) AS Failures

--- a/spec/lib/performance/metrics/request_stats_sender_spec.rb
+++ b/spec/lib/performance/metrics/request_stats_sender_spec.rb
@@ -4,7 +4,7 @@ describe Performance::Metrics::RequestStatsSender do
   let(:ip1) { "12.12.12.12" }
   let(:ip2) { "20.20.20.20" }
   let(:ip3) { "20.30.40.50" }
-  let(:time_string) { "2021-08-18 15:18:08" }
+  let(:time_string) { "2021-08-18T15:18:08" }
   let(:time) { Time.parse(time_string) }
 
   before :each do


### PR DESCRIPTION
### What
Format the timestamp in a way that Elasticsearch understands

### Why
Otherwise Elasticsearch will interpret the 'time' column to be a String
datatype instead of a Date one
