### PR TITLE
Add a new index to the sessions table

### DIFF
--- a/mysql/migrations/20210906124800_add_start_site_ip_success_index_to_sessions.rb
+++ b/mysql/migrations/20210906124800_add_start_site_ip_success_index_to_sessions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :sessions do
+      add_index %i[start siteIP success], name: "start_siteIP_successs"
+    end
+  end
+end


### PR DESCRIPTION
Index the Sessions table on start, siteIP, success

This facilitates queries such as

select count(*) from sessions where siteIP="x.x.x.x" and start>SUBDATE(NOW(),1) and success=1;

which are performed regularly in the the admin portal

Link to Trello card (if applicable): https://trello.com/c/QMqQGD6i/1545-handle-504-when-accessing-hmctss-page-in-the-super-admin-site
