### PR TITLE
Memoize S3 and Elasticsearch client

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,9 +1,9 @@
 class Services
   def self.s3_client
-    Aws::S3::Client.new(region: "eu-west-2")
+    @s3_client ||= Aws::S3::Client.new(region: "eu-west-2")
   end
 
   def self.elasticsearch_client
-    Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
+    @elasticsearch_client ||= Elasticsearch::Client.new host: ENV["VOLUMETRICS_ENDPOINT"]
   end
 end


### PR DESCRIPTION

### What
Memoize S3 and Elasticsearch client
### Why
To ensure we do not instantiate this multiple times.

We sometimes call ```Services.s3_client``` in a loop which can potentially cause faults
(for instance here: https://github.com/alphagov/govwifi-logging-api/blob/d2ce6a7249ce1361f50be2891a1f5ff1b87c1445/lib/performance/gateway/s3.rb#L11)
Link to Trello card (if applicable): 
https://trello.com/c/CRwyFPyk/1815-fix-syncs3todatabucket-scheduled-task