### PR TITLE
Use puma directly in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
-CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "8080"]
+CMD ["bundle", "exec", "puma", "-p", "8080", "--quiet"]

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,3 @@
-#\ --quiet
-# The above is needed to prevent rack from request logging
-
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
 require './app'


### PR DESCRIPTION
### What
Use puma directly in the Dockerfile

### Why
This should make it easier to pass more options to puma, I'm
particularly thinking of options concerning threads.


Link to Trello card: https://trello.com/c/knI00UhK/1851-use-puma-directly-for-the-logging-api