### PR TITLE
Use a minimum of 8 threads, and a maximum of 32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
-CMD ["bundle", "exec", "puma", "-p", "8080", "--quiet"]
+CMD ["bundle", "exec", "puma", "-p", "8080", "--quiet", "--threads", "8:32"]


### PR DESCRIPTION
### What
Use a minimum of 8 threads, and a maximum of 32. This is an increase on the values I see currently, which are a minimum
of 0 and a maximum of 5.

### Why
Not dropping down to 0 threads should help when new requests come in
and the service was previously idle. Allowing more threads should help
with handling more requests concurrently.


Link to Trello card: https://trello.com/c/Pxpt3w8e/1866-increase-puma-threads-for-the-logging-api