### PR TITLE
Increase the Sequel connection pool

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -11,7 +11,7 @@ DB = Sequel.connect(
   user: ENV.fetch("DB_USER"),
   password: ENV.fetch("DB_PASS"),
   read_timeout: 9999,
-  max_connections: 16,
+  max_connections: 32,
 )
 
 USER_DB = Sequel.connect(
@@ -21,7 +21,7 @@ USER_DB = Sequel.connect(
   user: ENV.fetch("USER_DB_USER"),
   password: ENV.fetch("USER_DB_PASS"),
   read_timeout: 9999,
-  max_connections: 16,
+  max_connections: 32,
 )
 
 if %w[production staging].include?(ENV["RACK_ENV"])


### PR DESCRIPTION
The number of Puma threads has been increased to a maximum of 32
and so to avoid Sequel::PoolTimeout errors we match the maximum
number of database connections.

See: https://github.com/alphagov/govwifi-logging-api/pull/498