### PR TITLE
Add an index hint to the roaming users count query

### DIFF
--- a/lib/performance/repository/session.rb
+++ b/lib/performance/repository/session.rb
@@ -27,6 +27,7 @@ class Performance::Repository::Session < Sequel::Model(:sessions)
                 username, count(distinct(location_id)) as roam_count
               FROM
                 sessions s
+              USE INDEX (start_siteIP_successs)
               INNER JOIN
                 ip_locations il on s.siteIP = il.ip
               WHERE


### PR DESCRIPTION
### What
Add an index hint to the roaming users count query

### Why
In the hope that this will mean the query executes in less
time. Currently it seems to be timing out, taking in excess of 2
hours.

The limited testing I've done suggests that MySQL does change
behaviour when using this hint, and that the query executes in ~17
minutes.


Link to Trello card: https://trello.com/c/tWoyciKg/2056-investigate-sentry-sequeldatabaseerror