### PR TITLE
Tweak read timeouts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 desc "require all classes"
 task :load_env do
+  # Set a long connection timeout here, since some of the queries run
+  # through the rake tasks may take several hours to complete
+  ::DB_CONNECTION_TIMEOUT = 12 * 60 * 60
+
   require "./lib/loader"
 end
 

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,11 @@ require "sequel"
 require "sensible_logging"
 require "sinatra/base"
 require "sinatra/json"
+
+# Set a short connection timeout, since queries here need to execute
+# before the request times out
+DB_CONNECTION_TIMEOUT = 10
+
 require "./lib/loader"
 
 class App < Sinatra::Base

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -20,7 +20,6 @@ USER_DB = Sequel.connect(
   database: ENV.fetch("USER_DB_NAME"),
   user: ENV.fetch("USER_DB_USER"),
   password: ENV.fetch("USER_DB_PASS"),
-  read_timeout: 9999,
   max_connections: 32,
 )
 

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -10,7 +10,7 @@ DB = Sequel.connect(
   database: ENV.fetch("DB_NAME"),
   user: ENV.fetch("DB_USER"),
   password: ENV.fetch("DB_PASS"),
-  read_timeout: 9999,
+  read_timeout: DB_CONNECTION_TIMEOUT,
   max_connections: 32,
 )
 


### PR DESCRIPTION
### What
Don't specify a `read_timeout` for the USER_DB, and set the DB `read_timeout` to different values in different contexts.

### Why
I'm looking in to timeout issues when running some Rake tasks, and I'm hoping the longer (12 hour) timeout will help.


Link to Trello card: https://trello.com/c/tWoyciKg/2056-investigate-sentry-sequeldatabaseerror