### PR TITLE
Add cumulative metrics to completion rate metrics

### DIFF
--- a/lib/performance/use_case/completion_rate.rb
+++ b/lib/performance/use_case/completion_rate.rb
@@ -9,11 +9,21 @@ class Performance::UseCase::CompletionRate
       period: @period,
       date: date.to_s,
       metric_name: "completion-rate",
+      cumulative_all_registered: cumulative_all_registered.count,
+      cumulative_sms_registered: cumulative_sms_registered.count,
+      cumulative_email_registered: cumulative_email_registered.count,
+      cumulative_sponsor_registered: cumulative_sponsor_registered.count,
+      cumulative_all_logged_in: cumulative_all_logged_in.count,
+      cumulative_sms_logged_in: cumulative_sms_logged_in.count,
+      cumulative_email_logged_in: cumulative_email_logged_in.count,
+      cumulative_sponsor_logged_in: cumulative_sponsor_logged_in.count,
+      all_registered: all_registered.count,
       sms_registered: sms_registered.count,
-      sms_logged_in: sms_logged_in.count,
       email_registered: email_registered.count,
-      email_logged_in: email_logged_in.count,
       sponsor_registered: sponsor_registered.count,
+      all_logged_in: all_logged_in.count,
+      sms_logged_in: sms_logged_in.count,
+      email_logged_in: email_logged_in.count,
       sponsor_logged_in: sponsor_logged_in.count,
     }
   end
@@ -26,16 +36,56 @@ private
     Performance::Repository::SignUp
   end
 
+  def cumulative_all_registered
+    repository.all(date)
+  end
+
+  def cumulative_sms_registered
+    cumulative_all_registered.self_sign.with_sms
+  end
+
+  def cumulative_email_registered
+    cumulative_all_registered.self_sign.with_email
+  end
+
+  def cumulative_sponsor_registered
+    cumulative_all_registered.sponsored
+  end
+
+  def cumulative_all_logged_in
+    cumulative_all_registered.with_successful_login
+  end
+
+  def cumulative_sms_logged_in
+    cumulative_sms_registered.with_successful_login
+  end
+
+  def cumulative_email_logged_in
+    cumulative_email_registered.with_successful_login
+  end
+
+  def cumulative_sponsor_logged_in
+    cumulative_sponsor_registered.with_successful_login
+  end
+
+  def all_registered
+    repository.send("#{@period}_before", date)
+  end
+
   def sms_registered
-    repository.self_sign.with_sms.send("#{@period}_before", date)
+    all_registered.self_sign.with_sms
   end
 
   def email_registered
-    repository.self_sign.with_email.send("#{@period}_before", date)
+    all_registered.self_sign.with_email
   end
 
   def sponsor_registered
-    repository.sponsored.send("#{@period}_before", date)
+    all_registered.sponsored
+  end
+
+  def all_logged_in
+    all_registered.with_successful_login
   end
 
   def sms_logged_in

--- a/spec/lib/performance/metrics/metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/metric_sender_spec.rb
@@ -34,12 +34,22 @@ describe Performance::Metrics::MetricSender do
     {
       "metric_name" => "completion-rate",
       "period" => "week",
+      "all_registered" => 0,
+      "all_logged_in" => 0,
       "sms_registered" => 0,
       "sms_logged_in" => 0,
       "email_registered" => 0,
       "email_logged_in" => 0,
       "sponsor_registered" => 0,
       "sponsor_logged_in" => 0,
+      "cumulative_all_registered" => 0,
+      "cumulative_all_logged_in" => 0,
+      "cumulative_sms_registered" => 0,
+      "cumulative_sms_logged_in" => 0,
+      "cumulative_email_registered" => 0,
+      "cumulative_email_logged_in" => 0,
+      "cumulative_sponsor_registered" => 0,
+      "cumulative_sponsor_logged_in" => 0,
       "date" => today.to_s,
     }
   end

--- a/spec/lib/performance/use_case/completion_rate_spec.rb
+++ b/spec/lib/performance/use_case/completion_rate_spec.rb
@@ -4,85 +4,113 @@ describe Performance::UseCase::CompletionRate do
   before do
     USER_DB[:userdetails].truncate
 
-    # Outside of date scope
+    # SMS self-registered outside of date scope, not logged in
     user_repo.create(
       username: "1",
-      created_at: today - 1,
+      created_at: today - 10,
       contact: "+1234567890",
       sponsor: "+1234567890",
+      last_login: nil,
     )
 
-    # Outside of date scope
-    # and logged in
+    # SMS self-registered outside of date scope and logged in
     user_repo.create(
       username: "2",
-      created_at: today - 1,
+      created_at: today - 10,
       contact: "+1234567890",
       sponsor: "+1234567890",
       last_login: today,
     )
 
-    # SMS self-registered within date scope
+    # SMS self-registered within date scope not logged in
     user_repo.create(
       username: "3",
-      created_at: today - 8,
+      created_at: today - 5,
       contact: "+2345678901",
       sponsor: "+2345678901",
+      last_login: nil,
     )
 
     # SMS self-registered within date scope
     # and logged in
     user_repo.create(
       username: "4",
-      created_at: today - 8,
+      created_at: today - 5,
       contact: "+2345678901",
       sponsor: "+2345678901",
       last_login: today,
     )
 
-    # SMS sponsor-registered within date scope
+    # SMS sponsor-registered outside date scope not logged in
     user_repo.create(
       username: "5",
-      created_at: today - 8,
+      created_at: today - 10,
       contact: "+2345678901",
       sponsor: "sponsor@example.com",
+      last_login: nil,
     )
 
-    # SMS sponsor-registered within date scope
-    # and logged in
+    # SMS sponsor-registered outside date scope logged in
     user_repo.create(
       username: "6",
-      created_at: today - 8,
+      created_at: today - 10,
       contact: "+2345678901",
       sponsor: "sponsor@example.com",
       last_login: today,
     )
 
-    # email self-registered within scope
+    # SMS sponsor-registered within date scope not logged in
     user_repo.create(
       username: "7",
-      created_at: today - 10,
-      contact: "me@example.com",
-      sponsor: "me@example.com",
+      created_at: today - 5,
+      contact: "+2345678901",
+      sponsor: "sponsor@example.com",
+      last_login: nil,
     )
 
-    # Email self-registered within scope
+    # SMS sponsor-registered within date scope
     # and logged in
     user_repo.create(
       username: "8",
-      created_at: today - 10,
-      contact: "me@example.com",
-      sponsor: "me@example.com",
+      created_at: today - 5,
+      contact: "+2345678901",
+      sponsor: "sponsor@example.com",
       last_login: today,
     )
 
-    # Email sponsored
-    # and logged in
+    # email self-registered outside scope not logged in
     user_repo.create(
       username: "9",
       created_at: today - 10,
       contact: "me@example.com",
-      sponsor: "sponsor@example.com",
+      sponsor: "me@example.com",
+      last_login: nil,
+    )
+
+    # Email self-registered outside scope and logged in
+    user_repo.create(
+      username: "10",
+      created_at: today - 10,
+      contact: "me@example.com",
+      sponsor: "me@example.com",
+      last_login: today,
+    )
+
+    # email self-registered within scope not logged in
+    user_repo.create(
+      username: "11",
+      created_at: today - 5,
+      contact: "me@example.com",
+      sponsor: "me@example.com",
+      last_login: nil,
+    )
+
+    # Email self-registered within scope and logged in
+    user_repo.create(
+      username: "12",
+      created_at: today - 5,
+      contact: "me@example.com",
+      sponsor: "me@example.com",
       last_login: today,
     )
   end
@@ -92,12 +120,22 @@ describe Performance::UseCase::CompletionRate do
       expect(subject.fetch_stats).to eq(
         metric_name: "completion-rate",
         period: "week",
+        all_registered: 6,
+        all_logged_in: 3,
         sms_registered: 2,
         sms_logged_in: 1,
         email_registered: 2,
         email_logged_in: 1,
-        sponsor_registered: 3,
-        sponsor_logged_in: 2,
+        sponsor_registered: 2,
+        sponsor_logged_in: 1,
+        cumulative_all_registered: 12,
+        cumulative_all_logged_in: 6,
+        cumulative_sms_registered: 4,
+        cumulative_sms_logged_in: 2,
+        cumulative_email_registered: 4,
+        cumulative_email_logged_in: 2,
+        cumulative_sponsor_registered: 4,
+        cumulative_sponsor_logged_in: 2,
         date: today.to_s,
       )
     end


### PR DESCRIPTION
### What
Add cumulative metrics to completion rate metrics

### Why
We want to know how many users have signed up over 3 journeys. (SMS/sponsored/Email) We
also want to know if they managed to sign in

Link to Trello card (if applicable): 
https://trello.com/c/yRa3gd0W/2264-create-data-chart-on-grafana-to-show-new-users-that-have-signed-in