### PR TITLE
Improve logging of the update_last_login rake task

### DIFF
--- a/lib/gdpr/use_case/populate_user_last_login.rb
+++ b/lib/gdpr/use_case/populate_user_last_login.rb
@@ -9,6 +9,7 @@ class Gdpr::UseCase::PopulateUserLastLogin
   def execute(date: Date.today)
     usernames = session_gateway.active_users(date:)
     last_login_gateway.set(date:, usernames:)
+    usernames.count
   end
 
 private

--- a/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
+++ b/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
@@ -58,6 +58,10 @@ describe Gdpr::UseCase::PopulateUserLastLogin do
         subject.execute(date: today)
         expect(user[:last_login].to_date).to eq(today)
       end
+
+      it "counts the number of users updated" do
+        expect(subject.execute(date: today)).to eq(1)
+      end
     end
 
     context "when the user was last logged in today" do

--- a/tasks/update_last_login.rb
+++ b/tasks/update_last_login.rb
@@ -1,8 +1,14 @@
 require "date"
 
 task update_yesterdays_last_login: :load_env do
-  Gdpr::UseCase::PopulateUserLastLogin.new(
+  date = Date.today.prev_day
+  logger = Logger.new($stdout)
+  logger.info("Populating the last_login field in the user database from the session database at #{date}")
+
+  number_updated = Gdpr::UseCase::PopulateUserLastLogin.new(
     session_gateway: Gdpr::Gateway::Session.new,
     last_login_gateway: Gdpr::Gateway::SetLastLogin.new,
   ).execute(date: Date.today.prev_day)
+
+  logger.info("Updated the last_login field of #{number_updated} records to #{date}")
 end


### PR DESCRIPTION
### What
Improve logging of the update_last_login rake task

###Why
We want to know when the task has started, which dates it uses
and how many records have been updated

This is to keep better track of how this task is performing