### PR TITLE
Update active_users query to not use the 'Date' function

### DIFF
--- a/lib/gdpr/gateway/session.rb
+++ b/lib/gdpr/gateway/session.rb
@@ -22,7 +22,7 @@ class Gdpr::Gateway::Session
 
   def active_users(date:)
     Session.select(:username).distinct
-      .where(Sequel.lit("DATE(start) = ?", date))
+      .where(Sequel.lit("start >= ? and start < ?", date, date.next_day))
       .map(:username)
   end
 end

--- a/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
+++ b/spec/lib/gdpr/use_case/populate_user_last_login_spec.rb
@@ -20,6 +20,24 @@ describe Gdpr::UseCase::PopulateUserLastLogin do
     userdetails.truncate
   end
 
+  it "only uses sessions with a start date within the day specified" do
+    sessions.insert(username: "AAAAAA", start: "2020-03-09 23:59:59")
+    sessions.insert(username: "BBBBBB", start: "2020-03-10 00:00:00")
+    sessions.insert(username: "CCCCCC", start: "2020-03-10 23:59:59")
+    sessions.insert(username: "DDDDDD", start: "2020-03-11 00:00:00")
+    userdetails.insert(username: "AAAAAA", last_login: nil)
+    userdetails.insert(username: "BBBBBB", last_login: nil)
+    userdetails.insert(username: "CCCCCC", last_login: nil)
+    userdetails.insert(username: "DDDDDD", last_login: nil)
+
+    subject.execute(date: Date.parse("2020-03-10"))
+
+    expect(userdetails.first(username: "AAAAAA")[:last_login]).to be_nil
+    expect(userdetails.first(username: "BBBBBB")[:last_login]).to eq(Time.parse("2020-03-10"))
+    expect(userdetails.first(username: "CCCCCC")[:last_login]).to eq(Time.parse("2020-03-10"))
+    expect(userdetails.first(username: "DDDDDD")[:last_login]).to be_nil
+  end
+
   context "with no user sessions" do
     it "Does not fail" do
       expect { subject.execute(date: today) }.not_to raise_error


### PR DESCRIPTION
### What
Update active_users query to not use the 'Date' function

### Why
Running the query previously proved to be extremely slow. This is
because the Sessions table contains > 100 million rows and the query
used the "Date" function to select rows with a start attribute within
the specified day. This means that for each of the >100 million rows
the date function is applied which also makes it impossible for the
database to use the relevant index.

The change removes the 'Date' function from the query and instead
performs a direct comparison.

An extra test was introduced to ensure we select the correct Session
rows.

Link to Trello card (if applicable): 
https://trello.com/c/yRa3gd0W/2264-create-data-chart-on-grafana-to-show-new-users-that-have-signed-in