### PR TITLE
Rename concourse container name from 'logging' to 'logging-api'

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -11,7 +11,7 @@ params:
   SERVICE_NAME: "logging-api-service"
   CLUSTER_NAME: "api-cluster"
   TASK_NAME: "logging-api"
-  CONTAINER_NAME: "logging"
+  CONTAINER_NAME: "logging-api"
 
 inputs:
   - name: src


### PR DESCRIPTION
### What

Make container name consistent with the name we use for the ECS service,
cluster and task definition. In our ECS task definitions we currently declare a container name that is different from the app, task and cluster name:
https://github.com/alphagov/govwifi-terraform/blob/13c45e4791ba82dfaba89cf68847eb2d720c4825/govwifi-api/logging-api-cluster.tf#L144

The name used is "logging" but elsewhere we use "logging-api" to refer
to related resources like the ECS service. This should be consistent -
"logging-api" should be used everywhere, and references to "logging"
should be deleted.

### Why
Using different values for the container name, service name and cluster name is confusing and makes writing the pipeline code more complicated.

This is related to PR:
https://github.com/alphagov/govwifi-terraform/pull/694

Link to Trello card: https://trello.com/c/RdBIxo8X/2428-make-logging-api-container-name-references-in-terraform-deploy-process-consistent



