### PR TITLE
Optimise the calculation of roaming users

### DIFF
--- a/lib/performance/use_case/roaming_users.rb
+++ b/lib/performance/use_case/roaming_users.rb
@@ -25,7 +25,7 @@ private
   end
 
   def roaming_users_count
-    repository.roaming_users_count(period:, date:).fetch(:total_roaming)
+    repository.roaming_users_count(period:).fetch(:total_roaming)
   end
 
   attr_reader :period, :date

--- a/mysql/migrations/20221123152200_add_success_site_ip_start_username_to_sessions.rb
+++ b/mysql/migrations/20221123152200_add_success_site_ip_start_username_to_sessions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :sessions do
+      add_index %i[success siteIP start username], name: "success_siteIP_start_username"
+    end
+  end
+end


### PR DESCRIPTION
### Why
The sessions table is getting very large and is slowing down the computation of roaming users.

### What
It is optimised by omitting the time interval which is hard to write and index for and is replaced by selecting for dates greater than a day/week/month ago

An index is added to the sessions database to optimise this query, which now runs in around 6 minutes on an M1 mac laptop.

Link to Jira card (if applicable):  https://technologyprogramme.atlassian.net/browse/GW-599
