### PR TITLE
Add logging to migration code

### DIFF
--- a/tasks/migrate.rb
+++ b/tasks/migrate.rb
@@ -10,6 +10,7 @@ namespace :db do
       database: ENV.fetch("DB_NAME"),
       user: ENV.fetch("DB_USER"),
       password: ENV.fetch("DB_PASS"),
+      logger: Logger.new($stdout),
     )
     Sequel::Migrator.run(db, "mysql/migrations", target: version)
   end


### PR DESCRIPTION
### What
When running migrations, the output is now logged

### Why
Currently, when migrations run, they run silently. This makes it hard to debug.

