### PR TITLE
Update the smoketest cleanup code

### DIFF
--- a/lib/smoketests/smoketest_cleanup.rb
+++ b/lib/smoketests/smoketest_cleanup.rb
@@ -4,21 +4,8 @@ class Smoketests::SmoketestCleanup
     logger = Logger.new($stdout)
     logger.info("Starting daily smoke test user and session deletion")
 
-    total = 0
-    while (users = next_batch_of_users).count.positive?
-      Session.where(username: users.select_map(:username)).delete
-      total += users.delete
-    end
-
-    logger.info("Finished daily smoke test user deletion, #{total} rows affected")
-  end
-
-private
-
-  def next_batch_of_users
-    User
-      .where { contact.like "govwifi-tests+%@digital.cabinet-office.gov.uk" }
-      .where { created_at < Time.now - (10 * 60) }
-      .limit(SESSION_BATCH_SIZE)
+    site_ips = ENV["SMOKE_TEST_IPS"].split(",").map(&:strip)
+    total = Session.where(siteIp: site_ips).delete
+    logger.info("Finished daily smoke test session deletion, #{total} rows affected")
   end
 end

--- a/spec/lib/performance/use_case/volumetrics_spec.rb
+++ b/spec/lib/performance/use_case/volumetrics_spec.rb
@@ -260,9 +260,9 @@ describe Performance::UseCase::Volumetrics do
 
     before do
       yesterday = today.prev_day
-      user_repository.create(username: "Email", contact: "foo@bar.com", created_at: yesterday.prev_month.next_day)
+      user_repository.create(username: "Email", contact: "foo@bar.com", created_at: yesterday.prev_month)
       user_repository.create(username: "SMS", contact: "1234567", created_at: yesterday.prev_day)
-      user_repository.create(username: "Notme", contact: "2345678", created_at: yesterday.prev_month)
+      user_repository.create(username: "Notme", contact: "2345678", created_at: yesterday.prev_month.prev_day)
     end
 
     it "counts signups for the previous month" do

--- a/spec/lib/smoketests/smoketest_cleanup_spec.rb
+++ b/spec/lib/smoketests/smoketest_cleanup_spec.rb
@@ -1,95 +1,26 @@
 describe Smoketests::SmoketestCleanup do
   before do
-    User.truncate
     Session.truncate
   end
-
-  context "Deleting smoke test users" do
-    context "Given no test users" do
-      before do
-        User.insert(username: "foo", contact: "foo@example.com", created_at: Date.today - 1)
-        User.insert(username: "bar", contact: "bar@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-      end
-
-      it "does not delete any users" do
-        expect { subject.clean }.not_to(change { User.count })
-      end
-
-      it "does not delete any sessions" do
-        expect { subject.clean }.not_to(change { Session.count })
-      end
-    end
-
-    context "Given one test user" do
-      before do
-        User.insert(username: "foo", contact: "foo@example.com", created_at: Date.today - 1)
-        User.insert(username: "bar", contact: "bar@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        User.insert(username: "baz", contact: "govwifi-tests+baz@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        Session.insert(username: "foo")
-        Session.insert(username: "bar")
-        Session.insert(username: "baz")
-      end
-
-      it "deletes only the old test user record" do
-        subject.clean
-        expect(User.select_map(:username)).to match_array(%w[foo bar])
-      end
-
-      it "deletes only associated sessions" do
-        subject.clean
-        expect(Session.select_map(:username)).to match_array(%w[foo bar])
-      end
-    end
-
-    context "Given multiple test users" do
-      before do
-        User.insert(username: "foo", contact: "govwifi-tests+foo@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        User.insert(username: "bar", contact: "govwifi-tests+bar@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        User.insert(username: "baz", contact: "govwifi-tests+baz@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        Session.insert(username: "foo")
-        Session.insert(username: "bar")
-        Session.insert(username: "baz")
-      end
-
-      it "deletes all the test users" do
-        expect { subject.clean }.to change { User.count }.from(3).to(0)
-      end
-      it "deletes all test sessions" do
-        expect { subject.clean }.to change { Session.count }.from(3).to(0)
-      end
-    end
-
-    context "Given a recently created test user" do
-      before do
-        User.insert(username: "foo", contact: "govwifi-tests+foo@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        User.insert(username: "bar", contact: "govwifi-tests+bar@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-        User.insert(username: "baz", contact: "govwifi-tests+baz@digital.cabinet-office.gov.uk")
-        Session.insert(username: "foo")
-        Session.insert(username: "bar")
-        Session.insert(username: "baz")
-      end
-
-      it "does not delete the recent test user" do
-        subject.clean
-        expect(User.select_map(:username)).to include("baz")
-      end
-    end
-    context "More sessions and username than the batch size" do
-      let(:number) { (Smoketests::SmoketestCleanup::SESSION_BATCH_SIZE * 2.5).round }
-      before :each do
-        username = "aaaaaa"
-        number.times do
-          username = username.next
-          User.insert(username:, contact: "govwifi-tests+baz@digital.cabinet-office.gov.uk", created_at: Date.today - 1)
-          2.times { Session.insert(username:) }
-        end
-      end
-      it "deletes all the test users" do
-        expect { subject.clean }.to change { User.count }.from(number).to(0)
-      end
-      it "deletes all test sessions" do
-        expect { subject.clean }.to change { Session.count }.from(number * 2).to(0)
-      end
-    end
+  before :each do
+    10.times { Session.create(siteIP: "1.2.3.4") }
+    10.times { Session.create(siteIP: "2.3.4.5") }
+  end
+  it "deletes all sessions" do
+    ENV["SMOKE_TEST_IPS"] = "1.2.3.4,2.3.4.5"
+    expect { Smoketests::SmoketestCleanup.new.clean }.to change { Session.count }.from(20).to(0)
+  end
+  it "ignores sessions from other IPs" do
+    ENV["SMOKE_TEST_IPS"] = "1.2.3.4"
+    expect { Smoketests::SmoketestCleanup.new.clean }.to change { Session.count }.from(20).to(10)
+    expect(Session.where(siteIP: "2.3.4.5").count).to eq(10)
+  end
+  it "ignores whitespace in the list of IPs" do
+    ENV["SMOKE_TEST_IPS"] = "  1.2.3.4  ,   2.3.4.5   "
+    expect { Smoketests::SmoketestCleanup.new.clean }.to change { Session.count }.from(20).to(0)
+  end
+  it "reports the number of rows deleted" do
+    ENV["SMOKE_TEST_IPS"] = "1.2.3.4"
+    expect { Smoketests::SmoketestCleanup.new.clean }.to output(/10 rows affected/).to_stdout
   end
 end


### PR DESCRIPTION
The smoke tests have recently changed. They now take care of removing users that have been generated during the tests.

The Session data however still has to be removed. This is now done by siteIP and a new environment variable is introduced 'SMOKE_TEST_IPS' that lists all the site ips that the smoke tests use so that the correct sessions will be deleted.

See also: https://github.com/alphagov/govwifi-terraform/pull/794

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-895