### PR TITLE
adding missing bundler lock platform entry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -199,6 +203,9 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-22
+  x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   aws-sdk-s3
@@ -229,4 +236,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.10
+   2.4.21


### PR DESCRIPTION
### What
gemfile.lock was missing platform x86_64-linux
