### PR TITLE
Metric code now directly uses Date instead of string

### DIFF
--- a/lib/performance/metrics/metric_sender.rb
+++ b/lib/performance/metrics/metric_sender.rb
@@ -15,13 +15,13 @@ module Performance::Metrics
       volumetrics: Performance::UseCase::Volumetrics,
     }.freeze
 
-    def initialize(metric:, period: :daily, date: nil)
+    def initialize(metric:, period: :daily, date: Date.today)
       raise ArgumentError unless PERIODS.values.include? period
       raise ArgumentError unless STATS.keys.include? metric
 
       @metric = metric
       @period = period
-      @date = date.to_s
+      @date = date
     end
 
     def to_s3

--- a/lib/performance/use_case/active_users.rb
+++ b/lib/performance/use_case/active_users.rb
@@ -1,7 +1,7 @@
 class Performance::UseCase::ActiveUsers
-  def initialize(period:, date: Date.today.to_s)
+  def initialize(period:, date: Date.today)
     @period = period
-    @date = Date.parse(date)
+    @date = date
   end
 
   def fetch_stats

--- a/lib/performance/use_case/completion_rate.rb
+++ b/lib/performance/use_case/completion_rate.rb
@@ -1,6 +1,6 @@
 class Performance::UseCase::CompletionRate
-  def initialize(date: Date.today.to_s, period: "week")
-    @date = Date.parse(date)
+  def initialize(date: Date.today, period: "week")
+    @date = date
     @period = period
   end
 

--- a/lib/performance/use_case/roaming_users.rb
+++ b/lib/performance/use_case/roaming_users.rb
@@ -1,7 +1,7 @@
 class Performance::UseCase::RoamingUsers
-  def initialize(period:, date: Date.today.to_s)
+  def initialize(period:, date: Date.today)
     @period = period.to_s
-    @date = Date.parse(date)
+    @date = date
   end
 
   def fetch_stats

--- a/lib/performance/use_case/volumetrics.rb
+++ b/lib/performance/use_case/volumetrics.rb
@@ -1,8 +1,8 @@
 class Performance::UseCase::Volumetrics
   attr_reader :period
 
-  def initialize(date: Date.today.to_s, period: "day")
-    @date = Date.parse(date)
+  def initialize(date: Date.today, period: "day")
+    @date = date
     @period = period
   end
 

--- a/spec/lib/performance/metrics/metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/metric_sender_spec.rb
@@ -8,19 +8,19 @@ describe Performance::Metrics::MetricSender do
   let(:elasticsearch_client) { spy }
 
   subject(:active_users) do
-    Performance::Metrics::MetricSender.new(period: "week", date: today.to_s, metric: :active_users)
+    Performance::Metrics::MetricSender.new(period: "week", date: today, metric: :active_users)
   end
 
   subject(:completion_rate) do
-    Performance::Metrics::MetricSender.new(period: "week", date: today.to_s, metric: :completion_rate)
+    Performance::Metrics::MetricSender.new(period: "week", date: today, metric: :completion_rate)
   end
 
   subject(:roaming_users) do
-    Performance::Metrics::MetricSender.new(period: "week", date: today.to_s, metric: :roaming_users)
+    Performance::Metrics::MetricSender.new(period: "week", date: today, metric: :roaming_users)
   end
 
   subject(:volumetrics) do
-    Performance::Metrics::MetricSender.new(period: "week", date: today.to_s, metric: :volumetrics)
+    Performance::Metrics::MetricSender.new(period: "week", date: today, metric: :volumetrics)
   end
 
   let(:active_users_expected_hash) do
@@ -85,12 +85,12 @@ describe Performance::Metrics::MetricSender do
   end
 
   it "rejects invalid periods" do
-    expect {  Performance::Metrics::MetricSender.new(period: "foo", date: Date.today.to_s, metric: :active_users) }
+    expect {  Performance::Metrics::MetricSender.new(period: "foo", date: Date.today, metric: :active_users) }
       .to raise_error(ArgumentError)
   end
 
   it "rejects invalid stats" do
-    expect {  Performance::Metrics::MetricSender.new(period: "week", date: Date.today.to_s, metric: :foo) }
+    expect {  Performance::Metrics::MetricSender.new(period: "week", date: Date.today, metric: :foo) }
       .to raise_error(ArgumentError)
   end
 

--- a/spec/lib/performance/use_case/active_users_spec.rb
+++ b/spec/lib/performance/use_case/active_users_spec.rb
@@ -8,7 +8,7 @@ describe Performance::UseCase::ActiveUsers do
   end
 
   context "weekly active users" do
-    subject { described_class.new(period: "week") }
+    subject { described_class.new(period: "week", date: today) }
 
     context "with users connecting once each in a week" do
       before do
@@ -140,7 +140,7 @@ describe Performance::UseCase::ActiveUsers do
   end
 
   context "monthly active users" do
-    subject { described_class.new(period: "month") }
+    subject { described_class.new(period: "month", date: today) }
 
     context "with users connecting once each in a month" do
       before do

--- a/spec/lib/performance/use_case/completion_rate_spec.rb
+++ b/spec/lib/performance/use_case/completion_rate_spec.rb
@@ -2,7 +2,7 @@ describe Performance::UseCase::CompletionRate do
   let(:user_repo) { Class.new(Performance::Repository::SignUp) { unrestrict_primary_key } }
   let(:today) { "1 February 2020 1PM" }
   let(:period) { "day" }
-  subject { described_class.new(date: Date.parse(today).to_s, period:).fetch_stats }
+  subject { described_class.new(date: Date.parse(today), period:).fetch_stats }
   before do
     USER_DB[:userdetails].truncate
   end

--- a/spec/lib/performance/use_case/roaming_users_spec.rb
+++ b/spec/lib/performance/use_case/roaming_users_spec.rb
@@ -1,5 +1,5 @@
 describe Performance::UseCase::RoamingUsers do
-  subject { described_class.new(period:) }
+  subject { described_class.new(period:, date: today) }
 
   let(:location_ip_links) { DB[:ip_locations] }
   let(:sessions) { DB[:sessions] }

--- a/spec/lib/performance/use_case/volumetrics_spec.rb
+++ b/spec/lib/performance/use_case/volumetrics_spec.rb
@@ -4,8 +4,9 @@ describe Performance::UseCase::Volumetrics do
 
   before do
     USER_DB[:userdetails].truncate
-    Timecop.travel(Time.local(2022, 7, 15))
   end
+
+  subject { Performance::UseCase::Volumetrics.new(date: today, period: "day") }
 
   context "given no signups" do
     it "returns stats with zero signups" do
@@ -229,7 +230,7 @@ describe Performance::UseCase::Volumetrics do
   end
 
   context "Date override" do
-    subject { described_class.new(date: "2018-08-10") }
+    subject { described_class.new(date: Date.parse("2018-08-10")) }
 
     before do
       user_repository.create(
@@ -257,7 +258,7 @@ describe Performance::UseCase::Volumetrics do
   end
 
   context "Stats for month" do
-    subject { described_class.new(period: "month") }
+    subject { described_class.new(period: "month", date: Date.new(2022, 7, 15)) }
 
     before do
       user_repository.create(username: "Email", contact: "foo@bar.com", created_at: Date.new(2022, 7, 1))

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -16,7 +16,7 @@ Performance::Metrics::PERIODS.each do |adverbial, period|
     logger.info("Creating #{adverbial} metrics for S3 with #{args[:date]}")
 
     Performance::Metrics::MetricSender::STATS.each_key do |metrics|
-      metric_sender = Performance::Metrics::MetricSender.new(period:, date: args[:date], metric: metrics)
+      metric_sender = Performance::Metrics::MetricSender.new(period:, date: Date.parse(args[:date]), metric: metrics)
       logger.info("[#{metric_sender.key}] Fetching and uploading metrics...")
 
       metric_sender.to_s3


### PR DESCRIPTION
This fixes an issue with the new user metrics and simplifies the passing of the date parameter.
