### PR TITLE
skip empty data

### DIFF
--- a/spec/lib/performance/use_case/sync_s3_to_data_bucket_spec.rb
+++ b/spec/lib/performance/use_case/sync_s3_to_data_bucket_spec.rb
@@ -13,22 +13,43 @@ describe Performance::UseCase::SyncS3ToDataBucket do
   let(:dest_bucket) { "dest-bucket" }
   let(:dest_key) { "dest-key" }
   let(:s3_client) { Performance::Metrics.fake_s3_client }
-  let(:data) do
-    [
-      { "a" => 1, "b" => 2 },
-      { "c" => 3, "d" => 4 },
-    ]
-  end
 
   before do
-    s3_client.put_object({ bucket: source_bucket, key: "prefix/one", body: data[0].to_json })
-    s3_client.put_object({ bucket: source_bucket, key: "prefix/two", body: data[1].to_json })
     allow(Services).to receive(:s3_client).and_return s3_client
-    subject.execute
   end
 
-  it "calls each on the s3 gateway" do
-    response = s3_client.get_object(bucket: dest_bucket, key: dest_key)
-    expect(JSON.parse(response.body.read)).to match_array(data)
+  context "when S3 has valid data" do
+    let(:data) do
+      [
+        { "a" => 1, "b" => 2 },
+        { "c" => 3, "d" => 4 },
+      ]
+    end
+
+    before do
+      s3_client.put_object(bucket: source_bucket, key: "prefix/one", body: data[0].to_json)
+      s3_client.put_object(bucket: source_bucket, key: "prefix/two", body: data[1].to_json)
+      subject.execute
+    end
+
+    it "writes all data records to the destination bucket" do
+      response = s3_client.get_object(bucket: dest_bucket, key: dest_key)
+      expect(JSON.parse(response.body.read)).to match_array(data)
+    end
+  end
+
+  context "when S3 contains empty or nil data" do
+    before do
+      s3_client.put_object(bucket: source_bucket, key: "prefix/one", body: { a: 1 }.to_json)
+      s3_client.put_object(bucket: source_bucket, key: "prefix/two", body: "") # empty string
+      s3_client.put_object(bucket: source_bucket, key: "prefix/three", body: nil) # nil body
+      subject.execute
+    end
+
+    it "skips empty or nil data and writes only valid records" do
+      response = s3_client.get_object(bucket: dest_bucket, key: dest_key)
+      parsed = JSON.parse(response.body.read)
+      expect(parsed).to eq([{ "a" => 1 }])
+    end
   end
 end


### PR DESCRIPTION
### What
JSON::ParserError: unexpected end of input at line 1 column 1 in Sentry.

sync_s3_to_data_bucket[govwifi-staging-metrics-bucket, govwifi-staging-export-data-bucket]

One or more datasets in the S3 source bucket were empty or missing. When SyncS3ToDataBucket#execute collected the data and downstream code attempted JSON.parse on the empty input it caused a crash.

Update: JSON::ParserError: unexpected end of input is still occurring because the skip empty or nil data logic is too late - the error is thrown inside the S3#each method before the SyncS3ToDataBucket code even gets to skip anything. I updated it and moved it to the S3#each method.

### Why
Sentry error

### Link to JIRA card (if applicable): 
[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)
https://technologyprogramme.atlassian.net/browse/GW-2454
