### PR TITLE
Gw 2719 recover active users for daily live reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-musl
 

--- a/lib/performance/metrics/api_publisher.rb
+++ b/lib/performance/metrics/api_publisher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+
+module Performance::Metrics
+  class ApiPublisher
+    def self.publish(stats)
+      connection.post do |req|
+        req.headers["Authorization"] = "Bearer #{ENV.fetch('METRICS_API_BEARER_TOKEN')}"
+        req.headers["Content-Type"] = "application/json"
+        req.body = stats.to_json
+      end
+    end
+
+    def self.connection
+      @connection ||= Faraday.new(url: ENV.fetch("METRICS_API_ENDPOINT"))
+    end
+  end
+end

--- a/lib/performance/metrics/daily_metrics_sender.rb
+++ b/lib/performance/metrics/daily_metrics_sender.rb
@@ -29,6 +29,12 @@ module Performance::Metrics
       S3Publisher.publish "#{@metric}/#{key}", stats
     end
 
+    def to_api
+      return if stats.nil?
+
+      ApiPublisher.publish stats
+    end
+
     def key
       "#{@metric}-#{@period}-#{@date}"
     end

--- a/spec/lib/performance/metrics/api_publisher_spec.rb
+++ b/spec/lib/performance/metrics/api_publisher_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe Performance::Metrics::ApiPublisher do
+  let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
+  let(:api_token) { "1e5e66d8c234912aaca969731b5d390385cdd882497d5e7fcd67efc7c485a5f4" }
+
+  before do
+    ENV["METRICS_API_ENDPOINT"] = api_endpoint
+    ENV["METRICS_API_BEARER_TOKEN"] = api_token
+  end
+
+  describe ".publish" do
+    let(:stats) { { "metric_name" => "monthly-rolling-window-total-active-users", "users" => 0 } }
+
+    it "POSTs stats to the metrics API" do
+      stub = stub_request(:post, api_endpoint)
+
+      described_class.publish(stats)
+
+      expect(stub).to have_been_requested.once
+    end
+
+    it "sends the stats as JSON with auth headers" do
+      stub = stub_request(:post, api_endpoint).with(
+        body: stats.to_json,
+        headers: {
+          "Authorization" => "Bearer #{api_token}",
+          "Content-Type" => "application/json",
+        },
+      )
+
+      described_class.publish(stats)
+
+      expect(stub).to have_been_requested.once
+    end
+  end
+end

--- a/spec/lib/performance/metrics/daily_metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/daily_metric_sender_spec.rb
@@ -105,4 +105,38 @@ describe Performance::Metrics::DailyMetricSender do
         .to eq(month_to_date_roaming_expected_hash)
     end
   end
+
+  describe "#to_api" do
+    let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
+
+    before do
+      ENV["METRICS_API_ENDPOINT"] = api_endpoint
+      ENV["METRICS_API_BEARER_TOKEN"] = "test-token"
+    end
+
+    it "sends 'monthly rolling total users' stats to the metrics API" do
+      stub = stub_request(:post, api_endpoint)
+
+      monthly_rolling_total.to_api
+
+      expect(stub).to have_been_requested.once
+    end
+
+    it "sends stats to the metrics API" do
+      stub = stub_request(:post, api_endpoint)
+
+      monthly_rolling_total.to_api
+
+      expect(stub).to have_been_requested.once
+    end
+
+    it "sends the correct stats hash" do
+      captured = nil
+      stub_request(:post, api_endpoint).with { |req| captured = JSON.parse(req.body); true }
+
+      monthly_rolling_total.to_api
+
+      expect(captured).to eq(monthly_rolling_total_expected_hash)
+    end
+  end
 end

--- a/spec/lib/performance/metrics/daily_metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/daily_metric_sender_spec.rb
@@ -132,7 +132,10 @@ describe Performance::Metrics::DailyMetricSender do
 
     it "sends the correct stats hash" do
       captured = nil
-      stub_request(:post, api_endpoint).with { |req| captured = JSON.parse(req.body); true }
+      stub_request(:post, api_endpoint).with do |req|
+        captured = JSON.parse(req.body)
+        true
+      end
 
       monthly_rolling_total.to_api
 

--- a/tasks/recover_active_users.rb
+++ b/tasks/recover_active_users.rb
@@ -24,6 +24,7 @@ PERIOD.each do |adverbial, period|
       logger.info("BEGIN: [#{metric_sender.key}] Fetching and uploading metrics...")
 
       metric_sender.to_s3
+      metric_sender.to_api
 
       logger.info("END: [#{metric_sender.key}] Done.")
     end


### PR DESCRIPTION
### What
Added a #to_api method to the rake task used for daily retrieval of user statistics.

### Why
Because the metrics api requires these results to be consumed by connected services.

### Link to JIRA card (if applicable): 
[GW-2719](https://technologyprogramme.atlassian.net/browse/GW-xxx)
