### PR TITLE
Add error, connection, and empty state logging for metrics API uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby File.read(".ruby-version").chomp
 
 gem "aws-sdk-s3"
 gem "faraday"
+gem "mutex_m"
 gem "opensearch-ruby"
 gem "puma"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
     mysql2 (0.5.7)
       bigdecimal
     net-http (0.9.1)
@@ -197,6 +198,7 @@ DEPENDENCIES
   factory_bot
   faker
   faraday
+  mutex_m
   mysql2 (~> 0.5.7)
   opensearch-ruby
   puma

--- a/lib/performance/metrics/daily_metrics_sender.rb
+++ b/lib/performance/metrics/daily_metrics_sender.rb
@@ -14,13 +14,14 @@ module Performance::Metrics
       month_to_date_roaming: Performance::UseCase::MonthToDateTotalRoamingUsers,
     }.freeze
 
-    def initialize(metric:, period: :daily, date: Date.today)
+    def initialize(metric:, period: :daily, date: Date.today, logger: Logger.new($stdout))
       raise ArgumentError unless PERIODS.values.include? period
       raise ArgumentError unless STATS.keys.include? metric
 
       @metric = metric
       @period = period
       @date = date
+      @logger = logger
     end
 
     def to_s3
@@ -30,9 +31,21 @@ module Performance::Metrics
     end
 
     def to_api
-      return if stats.nil?
+      if stats.nil?
+        @logger.info("[#{key}] No stats to upload.")
+        return
+      end
 
-      MetricsApiPublisher.publish stats
+      @logger.info("[#{key}] Contacting metrics API...")
+      response = MetricsApiPublisher.publish(stats)
+
+      if response&.success?
+        @logger.info("[#{key}] Metrics API upload succeeded (status: #{response.status}).")
+      elsif response
+        @logger.warn("[#{key}] Metrics API upload failed (status: #{response.status}): #{response.body}")
+      else
+        @logger.warn("[#{key}] Metrics API upload failed: connection or other error.")
+      end
     end
 
     def key

--- a/lib/performance/metrics/metrics_api_publisher.rb
+++ b/lib/performance/metrics/metrics_api_publisher.rb
@@ -7,12 +7,11 @@ require "logger"
 module Performance::Metrics
   class MetricsApiPublisher
     def self.publish(stats)
-      response = connection.post do |req|
+      connection.post do |req|
         req.headers["Authorization"] = "Bearer #{ENV.fetch('METRICS_API_BEARER_TOKEN')}"
         req.headers["Content-Type"] = "application/json"
         req.body = stats.to_json
       end
-      response
     rescue Faraday::Error => e
       logger.warn("Metrics API request failed: #{e.message} (endpoint: #{ENV.fetch('METRICS_API_ENDPOINT', 'unknown')})")
       nil

--- a/lib/performance/metrics/metrics_api_publisher.rb
+++ b/lib/performance/metrics/metrics_api_publisher.rb
@@ -7,13 +7,15 @@ require "logger"
 module Performance::Metrics
   class MetricsApiPublisher
     def self.publish(stats)
-      connection.post do |req|
+      response = connection.post do |req|
         req.headers["Authorization"] = "Bearer #{ENV.fetch('METRICS_API_BEARER_TOKEN')}"
         req.headers["Content-Type"] = "application/json"
         req.body = stats.to_json
       end
+      response
     rescue Faraday::Error => e
       logger.warn("Metrics API request failed: #{e.message} (endpoint: #{ENV.fetch('METRICS_API_ENDPOINT', 'unknown')})")
+      nil
     end
 
     def self.connection

--- a/spec/lib/performance/metrics/daily_metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/daily_metric_sender_spec.rb
@@ -6,20 +6,27 @@ describe Performance::Metrics::DailyMetricSender do
   let(:today) { Date.today }
   let(:s3_client) { Performance::Metrics.fake_s3_client }
 
+  let(:test_logger) { double("logger", info: nil, warn: nil) }
+
   subject(:monthly_rolling_total) do
-    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :monthly_rolling_total)
+    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :monthly_rolling_total, logger: test_logger)
   end
 
   subject(:monthly_rolling_roaming) do
-    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :monthly_rolling_roaming)
+    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :monthly_rolling_roaming, logger: test_logger)
   end
 
   subject(:month_to_date_total) do
-    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :month_to_date_total)
+    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :month_to_date_total, logger: test_logger)
   end
 
   subject(:month_to_date_roaming) do
-    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :month_to_date_roaming)
+    Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :month_to_date_roaming, logger: test_logger)
+  end
+
+  it "defaults to a standard logger writing to $stdout" do
+    sender = Performance::Metrics::DailyMetricSender.new(period: "day", date: today, metric: :monthly_rolling_total)
+    expect(sender.instance_variable_get(:@logger)).to be_a(Logger)
   end
 
   let(:monthly_rolling_total_expected_hash) do
@@ -140,6 +147,54 @@ describe Performance::Metrics::DailyMetricSender do
       monthly_rolling_total.to_api
 
       expect(captured).to eq(monthly_rolling_total_expected_hash)
+    end
+
+    context "when stats are present" do
+      before do
+        stub_request(:post, api_endpoint).to_return(status: 200, body: "success")
+      end
+
+      it "logs that it is contacting the metrics API and that the upload succeeded" do
+        expect(test_logger).to receive(:info).with(/Contacting metrics API/)
+        expect(test_logger).to receive(:info).with(/Metrics API upload succeeded \(status: 200\)/)
+        monthly_rolling_total.to_api
+      end
+    end
+
+    context "when stats are present but the API request returns a failure status code" do
+      before do
+        stub_request(:post, api_endpoint).to_return(status: 500, body: "internal error")
+      end
+
+      it "logs that it is contacting the API and that the upload failed with status and body" do
+        expect(test_logger).to receive(:info).with(/Contacting metrics API/)
+        expect(test_logger).to receive(:warn).with(/Metrics API upload failed \(status: 500\): internal error/)
+        monthly_rolling_total.to_api
+      end
+    end
+
+    context "when stats are present but the API request fails due to a connection error" do
+      before do
+        stub_request(:post, api_endpoint).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+      end
+
+      it "logs that it is contacting the API and that the upload failed due to a connection error" do
+        expect(test_logger).to receive(:info).with(/Contacting metrics API/)
+        expect(test_logger).to receive(:warn).with(/Metrics API upload failed: connection or other error/)
+        monthly_rolling_total.to_api
+      end
+    end
+
+    context "when stats are nil (no stats to upload)" do
+      before do
+        allow_any_instance_of(Performance::UseCase::MonthlyRollingWindowTotalActiveUsers)
+          .to receive(:fetch_stats).and_return(nil)
+      end
+
+      it "logs that there are no stats to upload" do
+        expect(test_logger).to receive(:info).with(/No stats to upload/)
+        monthly_rolling_total.to_api
+      end
     end
   end
 end

--- a/spec/lib/performance/metrics/metrics_api_publisher_spec.rb
+++ b/spec/lib/performance/metrics/metrics_api_publisher_spec.rb
@@ -12,12 +12,14 @@ describe Performance::Metrics::MetricsApiPublisher do
   describe ".publish" do
     let(:stats) { { "metric_name" => "monthly-rolling-window-total-active-users", "users" => 0 } }
 
-    it "POSTs stats to the metrics API" do
-      stub = stub_request(:post, api_endpoint)
+    it "POSTs stats to the metrics API and returns the Faraday response" do
+      stub = stub_request(:post, api_endpoint).to_return(status: 201, body: "created")
 
-      described_class.publish(stats)
+      response = described_class.publish(stats)
 
       expect(stub).to have_been_requested.once
+      expect(response).to be_a(Faraday::Response)
+      expect(response.status).to eq(201)
     end
 
     it "sends the stats as JSON with auth headers" do
@@ -50,8 +52,8 @@ describe Performance::Metrics::MetricsApiPublisher do
           stub_request(:post, api_endpoint).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
         end
 
-        it "does not raise an error" do
-          expect { described_class.publish(stats) }.not_to raise_error
+        it "does not raise an error and returns nil" do
+          expect(described_class.publish(stats)).to be_nil
         end
 
         it "logs a warning" do
@@ -65,8 +67,8 @@ describe Performance::Metrics::MetricsApiPublisher do
           stub_request(:post, api_endpoint).to_timeout
         end
 
-        it "does not raise an error" do
-          expect { described_class.publish(stats) }.not_to raise_error
+        it "does not raise an error and returns nil" do
+          expect(described_class.publish(stats)).to be_nil
         end
 
         it "logs a warning" do


### PR DESCRIPTION
### What
- Adds constructor-level logger configuration to DailyMetricSender
- Adds logging for when there are no statistics to upload
- Adds logging for when the metrics API is contacted
- Captures and logs the result of the API contact (success, API status failure, connection error)
- Explicitly returns response or nil from MetricsApiPublisher.publish
- Updates the Gemfile to specify mutex_m for Ruby 3.4 compatibility in tests