### PR TITLE
Fix metrics API publisher to join endpoint with /v1/record safely

### DIFF
--- a/lib/performance/metrics/metrics_api_publisher.rb
+++ b/lib/performance/metrics/metrics_api_publisher.rb
@@ -7,7 +7,7 @@ require "logger"
 module Performance::Metrics
   class MetricsApiPublisher
     def self.publish(stats)
-      connection.post do |req|
+      connection.post("v1/record") do |req|
         req.headers["Authorization"] = "Bearer #{ENV.fetch('METRICS_API_BEARER_TOKEN')}"
         req.headers["Content-Type"] = "application/json"
         req.body = stats.to_json
@@ -18,7 +18,12 @@ module Performance::Metrics
     end
 
     def self.connection
-      @connection ||= Faraday.new(url: ENV.fetch("METRICS_API_ENDPOINT"))
+      base_url = ENV.fetch("METRICS_API_ENDPOINT").chomp("/")
+      if @connection && @connection.url_prefix.to_s.chomp("/") == base_url
+        @connection
+      else
+        @connection = Faraday.new(url: base_url)
+      end
     end
 
     class << self

--- a/spec/lib/performance/metrics/daily_metric_sender_spec.rb
+++ b/spec/lib/performance/metrics/daily_metric_sender_spec.rb
@@ -114,7 +114,8 @@ describe Performance::Metrics::DailyMetricSender do
   end
 
   describe "#to_api" do
-    let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
+    let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk" }
+    let(:expected_api_url) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
 
     before do
       ENV["METRICS_API_ENDPOINT"] = api_endpoint
@@ -122,7 +123,7 @@ describe Performance::Metrics::DailyMetricSender do
     end
 
     it "sends 'monthly rolling total users' stats to the metrics API" do
-      stub = stub_request(:post, api_endpoint)
+      stub = stub_request(:post, expected_api_url)
 
       monthly_rolling_total.to_api
 
@@ -130,7 +131,7 @@ describe Performance::Metrics::DailyMetricSender do
     end
 
     it "sends stats to the metrics API" do
-      stub = stub_request(:post, api_endpoint)
+      stub = stub_request(:post, expected_api_url)
 
       monthly_rolling_total.to_api
 
@@ -139,7 +140,7 @@ describe Performance::Metrics::DailyMetricSender do
 
     it "sends the correct stats hash" do
       captured = nil
-      stub_request(:post, api_endpoint).with do |req|
+      stub_request(:post, expected_api_url).with do |req|
         captured = JSON.parse(req.body)
         true
       end
@@ -151,7 +152,7 @@ describe Performance::Metrics::DailyMetricSender do
 
     context "when stats are present" do
       before do
-        stub_request(:post, api_endpoint).to_return(status: 200, body: "success")
+        stub_request(:post, expected_api_url).to_return(status: 200, body: "success")
       end
 
       it "logs that it is contacting the metrics API and that the upload succeeded" do
@@ -163,7 +164,7 @@ describe Performance::Metrics::DailyMetricSender do
 
     context "when stats are present but the API request returns a failure status code" do
       before do
-        stub_request(:post, api_endpoint).to_return(status: 500, body: "internal error")
+        stub_request(:post, expected_api_url).to_return(status: 500, body: "internal error")
       end
 
       it "logs that it is contacting the API and that the upload failed with status and body" do
@@ -175,7 +176,7 @@ describe Performance::Metrics::DailyMetricSender do
 
     context "when stats are present but the API request fails due to a connection error" do
       before do
-        stub_request(:post, api_endpoint).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+        stub_request(:post, expected_api_url).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
       end
 
       it "logs that it is contacting the API and that the upload failed due to a connection error" do

--- a/spec/lib/performance/metrics/metrics_api_publisher_spec.rb
+++ b/spec/lib/performance/metrics/metrics_api_publisher_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe Performance::Metrics::MetricsApiPublisher do
-  let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
+  let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk" }
+  let(:expected_url) { "https://metrics.development.wifi.service.gov.uk/v1/record" }
   let(:api_token) { "1e5e66d8c234912aaca969731b5d390385cdd882497d5e7fcd67efc7c485a5f4" }
 
   before do
@@ -13,7 +14,7 @@ describe Performance::Metrics::MetricsApiPublisher do
     let(:stats) { { "metric_name" => "monthly-rolling-window-total-active-users", "users" => 0 } }
 
     it "POSTs stats to the metrics API and returns the Faraday response" do
-      stub = stub_request(:post, api_endpoint).to_return(status: 201, body: "created")
+      stub = stub_request(:post, expected_url).to_return(status: 201, body: "created")
 
       response = described_class.publish(stats)
 
@@ -23,7 +24,7 @@ describe Performance::Metrics::MetricsApiPublisher do
     end
 
     it "sends the stats as JSON with auth headers" do
-      stub = stub_request(:post, api_endpoint).with(
+      stub = stub_request(:post, expected_url).with(
         body: stats.to_json,
         headers: {
           "Authorization" => "Bearer #{api_token}",
@@ -34,6 +35,19 @@ describe Performance::Metrics::MetricsApiPublisher do
       described_class.publish(stats)
 
       expect(stub).to have_been_requested.once
+    end
+
+    context "when the endpoint has a trailing slash" do
+      let(:api_endpoint) { "https://metrics.development.wifi.service.gov.uk/" }
+
+      it "POSTs stats to the joined /v1/record endpoint correctly without double slashes" do
+        stub = stub_request(:post, expected_url).to_return(status: 201, body: "created")
+
+        response = described_class.publish(stats)
+
+        expect(stub).to have_been_requested.once
+        expect(response.status).to eq(201)
+      end
     end
 
     describe "when the API request fails" do
@@ -49,7 +63,7 @@ describe Performance::Metrics::MetricsApiPublisher do
 
       context "when there is a connection error" do
         before do
-          stub_request(:post, api_endpoint).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+          stub_request(:post, expected_url).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
         end
 
         it "does not raise an error and returns nil" do
@@ -64,7 +78,7 @@ describe Performance::Metrics::MetricsApiPublisher do
 
       context "when there is a timeout" do
         before do
-          stub_request(:post, api_endpoint).to_timeout
+          stub_request(:post, expected_url).to_timeout
         end
 
         it "does not raise an error and returns nil" do


### PR DESCRIPTION
### What
Fixes an issue where the MetricsApiPublisher was not posting metrics data to the correct `/v1/record` endpoint.

### How
- Strips trailing slash from the base endpoint configured via the `METRICS_API_ENDPOINT` variable.
- Sets up the Faraday connection to relatively target `v1/record` during requests.
- Added tests for endpoints both with and without trailing slashes in `metrics_api_publisher_spec.rb` to prevent future regressions.
- Aligned `daily_metric_sender_spec.rb` to use the base endpoint structure.