### PR TITLE
Upgrade Sessions DB Version To MYSQL 8.4

### DIFF
--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -2,7 +2,7 @@
 # API will be run by the developer outside of docker compose.
 services:
   user_and_session_db:
-    image: mysql:8.0
+    image: mysql:8.4
     ports:
       - "53306:3306"
     environment:

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,1 +1,1 @@
-FROM mysql:8.0
+FROM mysql:8.4


### PR DESCRIPTION
### What
Upgrade Sessions DB Version To MYSQL 8.4

### Why
This is to match the version we are now running in production. It relates to: GovWifi/pull/1020

Remove "--==default-authentication-plugin==" as it is no longer supported in MYSQL 8.4 and causes an error, when testing locally.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2813
